### PR TITLE
[chore] 빌드 의존성 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,10 @@ plugins {
 allprojects {
     group = 'B6F2'
     version = '0.0.1-SNAPSHOT'
+
+    repositories {
+        mavenCentral()
+    }
 }
 
 subprojects {
@@ -24,10 +28,6 @@ subprojects {
         compileOnly {
             extendsFrom annotationProcessor
         }
-    }
-
-    repositories {
-        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
## 🔧 어떤 문제인가요?

> `~/.gradle dependencies` 명령으로 의존성 확신 시 빌드 실패 문제

## ✏️ 작업 상세 내용

- [x] root 경로의 `build.gradle`파일의 repositories를 allprojects 안으로 이동