### PR TITLE
feat: gps 신호를 queue 에 넣는 기능 구현

### DIFF
--- a/monicar-emulator/src/main/java/org/emulator/pipe/Gps.java
+++ b/monicar-emulator/src/main/java/org/emulator/pipe/Gps.java
@@ -1,0 +1,7 @@
+package org.emulator.pipe;
+
+public record Gps(
+	double lat,
+	double lon
+) {
+}

--- a/monicar-emulator/src/main/java/org/emulator/pipe/GpsPipeQueue.java
+++ b/monicar-emulator/src/main/java/org/emulator/pipe/GpsPipeQueue.java
@@ -1,0 +1,15 @@
+package org.emulator.pipe;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GpsPipeQueue {
+
+	@Bean
+	public ConcurrentLinkedQueue<Gps> gpsConcurrentLinkedQueue() {
+		return new ConcurrentLinkedQueue<>();
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/sensor/GpsDetector.java
+++ b/monicar-emulator/src/main/java/org/emulator/sensor/GpsDetector.java
@@ -1,17 +1,24 @@
 package org.emulator.sensor;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.emulator.pipe.Gps;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@RequiredArgsConstructor
 @Component
 public class GpsDetector implements SensorDetector {
+	private final ConcurrentLinkedQueue<Gps> gpsPipeQueue;
 
 	@Scheduled(initialDelay = 1000, fixedDelay = 1000)
 	@Override
 	public void detect() {
 		log.info("[Thread: {}] {}", Thread.currentThread().getName(), "Detecting... GPS");
+		gpsPipeQueue.add(new Gps(20.111111, 30.111111));
 	}
 }


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

> gps 신호를 여러 스레드에서 접근할 수 있는 Queue 에 적재하는 기능 구현

## #️⃣ 연관된 이슈

#38 

## 💡 리뷰어에게 하고 싶은 말

- 동시성 문제 방지를 위해 concurrent 패키지의 자료구조를 활용하였습니다.

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
