### PR TITLE
[test] http 요청 테스트

### DIFF
--- a/monicar-emulator/build.gradle
+++ b/monicar-emulator/build.gradle
@@ -3,6 +3,8 @@ dependencies {
     implementation 'org.springframework:spring-aspects'
     implementation 'org.springframework.retry:spring-retry'
 
+    testImplementation 'org.mock-server:mockserver-netty:5.15.0'
+
     implementation project(':monicar-common')
 }
 

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/RestClientService.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/RestClientService.java
@@ -1,7 +1,9 @@
 package org.emulator.device.infrastructure.external;
 
+import java.io.InputStream;
 import java.util.Map;
 
+import org.common.dto.CommonResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
@@ -19,18 +21,19 @@ public class RestClientService {
 		return restClients.get(path);
 	}
 
-	public <T> T post(
+	public CommonResponse post(
 		RestClient restClient,
+		String endPoint,
 		Object body,
-		Map<String, String> headers,
-		Class<T> responseType
+		Map<String, String> headers
 	) {
 		return restClient.post()
+			.uri(uriBuilder -> uriBuilder.path(endPoint).build())
 			.headers(header -> headers.forEach(header::add))
 			.body(body)
 			.exchange((request, response) -> {
-				String responseBody = response.getBody().toString();
-				return objectMapper.readValue(responseBody, responseType);
+				InputStream responseBody = response.getBody();
+				return objectMapper.readValue(responseBody, CommonResponse.class);
 			});
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/RestClientVehicleCommandSender.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/RestClientVehicleCommandSender.java
@@ -29,9 +29,9 @@ public class RestClientVehicleCommandSender implements VehicleCommandSender {
 
 		return restClientService.post(
 			restClient,
+			"key-on",
 			onCommand,
-			headers,
-			CommonResponse.class
+			headers
 		);
 	}
 

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/UrlPathEnum.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/UrlPathEnum.java
@@ -11,6 +11,6 @@ public enum UrlPathEnum {
 	}
 
 	public String getApiUrl() {
-		return "http://localhost:8090/api/v1" + path + "/";
+		return "http://localhost:8081/api/v1/" + path + "/";
 	}
 }

--- a/monicar-emulator/src/test/java/org/emulator/device/infrastructure/external/RestClientServiceTest.java
+++ b/monicar-emulator/src/test/java/org/emulator/device/infrastructure/external/RestClientServiceTest.java
@@ -1,0 +1,79 @@
+package org.emulator.device.infrastructure.external;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockserver.model.HttpRequest.*;
+import static org.mockserver.model.HttpResponse.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.common.dto.CommonResponse;
+import org.emulator.device.domain.GpsStatus;
+import org.emulator.device.domain.OnInfo;
+import org.emulator.device.infrastructure.external.command.OnCommand;
+import org.emulator.device.infrastructure.util.HeaderName;
+import org.emulator.device.infrastructure.util.HeaderUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockserver.integration.ClientAndServer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = RestClientFactory.class)
+class RestClientServiceTest {
+
+	@Autowired
+	private RestClientService restClientService;
+
+	private ClientAndServer mockServer;
+
+	private ObjectMapper mapper = new ObjectMapper();
+
+	@BeforeEach
+	public void setUP() {
+		mockServer = ClientAndServer.startClientAndServer(8081);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		mockServer.stop();
+	}
+
+	@DisplayName("시동 on 요청 성공 테스트입니다")
+	@Test
+	void postKeyOn() throws Exception {
+		//given
+		RestClient restClient = restClientService.getRestClient(UrlPathEnum.CONTROL_CENTER);
+		OnCommand command = OnCommand.of(OnInfo.create(LocalDateTime.now(), GpsStatus.A, 20.111111, 30.111111, 5000));
+		CommonResponse expected = new CommonResponse("000", "Success", "01234567890");
+
+		mockServer.when(
+			request()
+				.withMethod("POST")
+				.withPath("/api/v1/control-center/key-on")
+				.withBody(mapper.writeValueAsString(command)))
+			.respond(
+				response()
+					.withStatusCode(200)
+					.withBody(mapper.writeValueAsString(expected))
+			);
+
+		//when
+		CommonResponse result = restClientService.post(
+			restClient,
+			"key-on",
+			command,
+			HeaderUtils.additionalHeaders(HeaderName.TUID)
+		);
+
+		//then
+		assertEquals(expected, result);
+	}
+}


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

시동 on http 요청 테스트 코드입니다

## #️⃣ 연관된 이슈

#44 

## 💡 리뷰어에게 하고 싶은 말

- MockServer Netty 를 의존성 주입 하여 목서버로 http 요청 테스트를 진행했습니다.
- 요청 로직 중 response.getbody() 반환값 타입 에러를 수정했습니다.
- RestClient에 dto를 넘길 때 자동으로 직렬화해준다는 것을 확인했습니다.

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인