### PR TITLE
[Feature] Collector 모듈 내 vehicle entity 생성

### DIFF
--- a/monicar-collector/src/main/java/org/collector/application/CycleInfoService.java
+++ b/monicar-collector/src/main/java/org/collector/application/CycleInfoService.java
@@ -19,7 +19,7 @@ public class CycleInfoService {
 	public void cycleInfoSave(final CycleInfoRequest request) {
 		List<CycleInfo> cycleInfos = request.cList().stream()
 			.map(cListRequest -> CycleInfo.builder()
-				.sec(cListRequest.sec())
+				.interval_at(cListRequest.interval_at())
 				.gcd(cListRequest.gcd())
 				.lat(CycleInfo.convertToSixDecimalPlaces(cListRequest.lat()))
 				.lon(CycleInfo.convertToSixDecimalPlaces(cListRequest.lon()))

--- a/monicar-collector/src/main/java/org/collector/domain/CycleInfo.java
+++ b/monicar-collector/src/main/java/org/collector/domain/CycleInfo.java
@@ -3,8 +3,11 @@ package org.collector.domain;
 import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 import org.collector.presentation.dto.GCD;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,6 +15,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,7 +34,9 @@ public class CycleInfo implements Serializable {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private long id;
-	private int sec;
+	@CreatedDate
+	@DateTimeFormat(pattern = "yyyy-MM-dd/HH:mm:ss")
+	private LocalDateTime interval_at;
 	@Enumerated(EnumType.STRING)
 	private GCD gcd;
 	private BigDecimal lat;
@@ -38,6 +45,9 @@ public class CycleInfo implements Serializable {
 	private int spd;
 	private int sum;
 	private int bat;
+	@ManyToOne
+	@JoinColumn(name = "vehicle_id")
+	private Vehicle vehicle;
 
 	public static BigDecimal convertToSixDecimalPlaces(Double value) {
 		return BigDecimal.valueOf(value / 1000000.0);

--- a/monicar-collector/src/main/java/org/collector/domain/CycleInfo.java
+++ b/monicar-collector/src/main/java/org/collector/domain/CycleInfo.java
@@ -7,9 +7,11 @@ import java.time.LocalDateTime;
 
 import org.collector.presentation.dto.GCD;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -28,6 +30,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class CycleInfo implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/monicar-collector/src/main/java/org/collector/domain/Vehicle.java
+++ b/monicar-collector/src/main/java/org/collector/domain/Vehicle.java
@@ -1,0 +1,39 @@
+package org.collector.domain;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Vehicle implements Serializable {
+	@Serial
+	private static final long serialVersionUID = 1L;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "vehicle_id")
+	private long id;
+	private long mdn;
+	private String tid;
+	private long mid;
+	private int pv;
+	private long did;
+	private String dFWVer;
+}

--- a/monicar-collector/src/main/java/org/collector/domain/Vehicle.java
+++ b/monicar-collector/src/main/java/org/collector/domain/Vehicle.java
@@ -3,11 +3,8 @@ package org.collector.domain;
 import java.io.Serial;
 import java.io.Serializable;
 
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -22,7 +19,6 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 public class Vehicle implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;

--- a/monicar-collector/src/main/java/org/collector/presentation/dto/CListRequest.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/dto/CListRequest.java
@@ -1,12 +1,17 @@
 package org.collector.presentation.dto;
 
+import java.time.LocalDateTime;
+
 import org.hibernate.validator.constraints.Range;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import jakarta.validation.constraints.NotNull;
 
 public record CListRequest(
 	@NotNull(message = "발생시간은 필수 입력값입니다.")
-	Integer sec,
+	@JsonFormat(pattern = "yyyyMMddHHmm")
+	LocalDateTime interval_at,
 
 	@NotNull(message = "유효하지 않은 GPS상태 값이 입력되었습니다.")
 	GCD gcd,

--- a/monicar-collector/src/main/java/org/collector/presentation/dto/CListRequest.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/dto/CListRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record CListRequest(
 	@NotNull(message = "발생시간은 필수 입력값입니다.")
-	@JsonFormat(pattern = "yyyyMMddHHmm")
+	@JsonFormat(pattern = "yyyyMMddHHmmss")
 	LocalDateTime interval_at,
 
 	@NotNull(message = "유효하지 않은 GPS상태 값이 입력되었습니다.")

--- a/monicar-collector/src/main/java/org/collector/presentation/dto/CycleInfoRequest.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/dto/CycleInfoRequest.java
@@ -1,12 +1,9 @@
 package org.collector.presentation.dto;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.collector.common.annotation.MatchCycleSize;
 import org.hibernate.validator.constraints.Range;
-
-import com.fasterxml.jackson.annotation.JsonFormat;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -29,10 +26,6 @@ public record CycleInfoRequest(
 
 	@NotNull(message = "디바이스 ID는 필수 입력값입니다.")
 	Integer did,
-
-	@NotNull(message = "발생 시간은 필수 입력값입니다.")
-	@JsonFormat(pattern = "yyyyMMddHHmm")
-	LocalDateTime oTime,
 
 	@NotNull(message = "주기 정보 개수는 필수 입력값입니다.")
 	Integer cCnt,


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

- Collector 모듈 내 vehicle entity 생성
- CycleInfoRequest 내에 oTime 필드 제거
- CycleInfo 도메인 내 sec필드 -> interval_at로 변경
- CycleInfo와 Vehicle N:1 단방향 지정

## #️⃣ 연관된 이슈

#59 

## 💡 리뷰어에게 하고 싶은 말

- 주기정보와 차량은 N:1 관계이므로 이를 위해 다대일 단방향 지정하였습니다. 
- 양방향으로 지정하지 않은 이유는 나중에 역방향으로 객체 탐색이 꼭 필요하다고 느낄 때 추가하는 것이 좋다고 생각하였기 때문입니다.

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인