### PR TITLE
feat: 테이블 엔티티 설계

### DIFF
--- a/monicar-control-center/build.gradle
+++ b/monicar-control-center/build.gradle
@@ -3,6 +3,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
 
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    testImplementation("org.testcontainers:testcontainers")
+    testImplementation("org.testcontainers:mysql")
 }
 
 tasks.bootJar {

--- a/monicar-control-center/src/main/java/org/controlcenter/ControlCenterApplication.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/ControlCenterApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class ControlCenterApplication {
-    public static void main(String[] args) {
-        SpringApplication.run(ControlCenterApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(ControlCenterApplication.class, args);
+	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/Alarm.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/Alarm.java
@@ -1,0 +1,18 @@
+package org.controlcenter.alarm.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Alarm {
+	private Long id;
+	private Long managerId;
+	private String description;
+	private AlarmStatus status;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/AlarmStatus.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/AlarmStatus.java
@@ -1,0 +1,6 @@
+package org.controlcenter.alarm.domain;
+
+public enum AlarmStatus {
+	CHECKED,
+	UNCHECKED
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/AlarmJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/AlarmJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.alarm.infrastructure.jpa;
+
+import org.controlcenter.alarm.infrastructure.jpa.entity.AlarmEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmJpaRepository extends JpaRepository<AlarmEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/entity/AlarmEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/entity/AlarmEntity.java
@@ -1,0 +1,69 @@
+package org.controlcenter.alarm.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.alarm.domain.Alarm;
+import org.controlcenter.alarm.domain.AlarmStatus;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "alarm")
+public class AlarmEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "alarm_id")
+	private Long id;
+
+	private Long managerId;
+
+	private String description;
+
+	@Enumerated(value = EnumType.STRING)
+	private AlarmStatus status;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static AlarmEntity from(Alarm alarm) {
+		AlarmEntity alarmEntity = new AlarmEntity();
+		alarmEntity.id = alarm.getId();
+		alarmEntity.managerId = alarm.getManagerId();
+		alarmEntity.description = alarm.getDescription();
+		alarmEntity.status = alarm.getStatus();
+		alarmEntity.createdAt = alarm.getCreatedAt();
+		alarmEntity.updatedAt = alarm.getUpdatedAt();
+		alarmEntity.deletedAt = alarm.getDeletedAt();
+		return alarmEntity;
+	}
+
+	public Alarm toDomain() {
+		return Alarm.builder()
+			.id(id)
+			.managerId(managerId)
+			.description(description)
+			.status(status)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/common/exception/BusinessException.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/exception/BusinessException.java
@@ -1,8 +1,8 @@
 package org.controlcenter.common.exception;
 
-import lombok.Getter;
-
 import org.controlcenter.common.response.code.ErrorCode;
+
+import lombok.Getter;
 
 @Getter
 public class BusinessException extends RuntimeException {

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/Company.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/Company.java
@@ -1,0 +1,17 @@
+package org.controlcenter.company.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Company {
+	private Long id;
+	private String companyName;
+	private String businessRegistrationNumber;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/Department.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/Department.java
@@ -1,0 +1,17 @@
+package org.controlcenter.company.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Department {
+	private Long id;
+	private Long companyId;
+	private String departmentName;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/Manager.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/Manager.java
@@ -1,0 +1,22 @@
+package org.controlcenter.company.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Manager {
+	private Long id;
+	private Long departmentId;
+	private String email;
+	private String loginId;
+	private String password;
+	private String nickname;
+	private Role role;
+	private LocalDateTime lastLoginedAt;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/Role.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/Role.java
@@ -1,0 +1,6 @@
+package org.controlcenter.company.domain;
+
+public enum Role {
+	ROLE_USER,
+	ROLE_ADMIN
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.company.infrastructure.jpa;
+
+import org.controlcenter.company.infrastructure.jpa.entity.CompanyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyJpaRepository extends JpaRepository<CompanyEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/DepartmentJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/DepartmentJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.company.infrastructure.jpa;
+
+import org.controlcenter.company.infrastructure.jpa.entity.DepartmentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DepartmentJpaRepository extends JpaRepository<DepartmentEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/ManagerJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/ManagerJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.company.infrastructure.jpa;
+
+import org.controlcenter.company.infrastructure.jpa.entity.ManagerEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ManagerJpaRepository extends JpaRepository<ManagerEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/CompanyEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/CompanyEntity.java
@@ -1,0 +1,61 @@
+package org.controlcenter.company.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.company.domain.Company;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "company")
+public class CompanyEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "company_id")
+	private Long id;
+
+	private String companyName;
+
+	private String businessRegistrationNumber;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static CompanyEntity from(Company company) {
+		CompanyEntity companyEntity = new CompanyEntity();
+		companyEntity.id = company.getId();
+		companyEntity.companyName = company.getCompanyName();
+		companyEntity.businessRegistrationNumber = company.getBusinessRegistrationNumber();
+		companyEntity.createdAt = company.getCreatedAt();
+		companyEntity.updatedAt = company.getUpdatedAt();
+		companyEntity.deletedAt = company.getDeletedAt();
+		return companyEntity;
+	}
+
+	public Company toDomain() {
+		return Company.builder()
+			.id(id)
+			.companyName(companyName)
+			.businessRegistrationNumber(businessRegistrationNumber)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/DepartmentEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/DepartmentEntity.java
@@ -1,0 +1,61 @@
+package org.controlcenter.company.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.company.domain.Department;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "department")
+public class DepartmentEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "department_id")
+	private Long id;
+
+	private Long companyId;
+
+	private String departmentName;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static DepartmentEntity from(Department department) {
+		DepartmentEntity departmentEntity = new DepartmentEntity();
+		departmentEntity.id = department.getId();
+		departmentEntity.companyId = department.getCompanyId();
+		departmentEntity.departmentName = department.getDepartmentName();
+		departmentEntity.createdAt = department.getCreatedAt();
+		departmentEntity.updatedAt = department.getUpdatedAt();
+		departmentEntity.deletedAt = department.getDeletedAt();
+		return departmentEntity;
+	}
+
+	public Department toDomain() {
+		return Department.builder()
+			.id(id)
+			.companyId(companyId)
+			.departmentName(departmentName)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/ManagerEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/ManagerEntity.java
@@ -1,0 +1,85 @@
+package org.controlcenter.company.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.company.domain.Manager;
+import org.controlcenter.company.domain.Role;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "manager")
+public class ManagerEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "manager_id")
+	private Long id;
+
+	private Long departmentId;
+
+	private String email;
+
+	private String loginId;
+
+	private String password;
+
+	private String nickname;
+
+	@Enumerated(value = EnumType.STRING)
+	private Role role;
+
+	private LocalDateTime lastLoginedAt;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static ManagerEntity from(Manager manager) {
+		ManagerEntity managerEntity = new ManagerEntity();
+		managerEntity.id = manager.getId();
+		managerEntity.departmentId = manager.getDepartmentId();
+		managerEntity.email = manager.getEmail();
+		managerEntity.loginId = manager.getLoginId();
+		managerEntity.password = manager.getPassword();
+		managerEntity.nickname = manager.getNickname();
+		managerEntity.role = manager.getRole();
+		managerEntity.lastLoginedAt = manager.getLastLoginedAt();
+		managerEntity.createdAt = manager.getCreatedAt();
+		managerEntity.updatedAt = manager.getUpdatedAt();
+		managerEntity.deletedAt = manager.getDeletedAt();
+		return managerEntity;
+	}
+
+	public Manager toDomain() {
+		return Manager.builder()
+			.id(id)
+			.departmentId(departmentId)
+			.email(email)
+			.loginId(loginId)
+			.password(password)
+			.nickname(nickname)
+			.role(role)
+			.lastLoginedAt(lastLoginedAt)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/config/JpaConfig.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package org.controlcenter.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/geoinfo/domain/CycleInfo.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/geoinfo/domain/CycleInfo.java
@@ -1,0 +1,26 @@
+package org.controlcenter.geoinfo.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CycleInfo {
+	private long id;
+	private GpsStatus status;
+	private BigDecimal lat;
+	private BigDecimal lon;
+	private Integer ang;
+	private Integer spd;
+	private LocalDateTime intervalAt;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+
+	public static BigDecimal convertToSixDecimalPlaces(Double value) {
+		return BigDecimal.valueOf(value / 1000000.0);
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/geoinfo/domain/GpsStatus.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/geoinfo/domain/GpsStatus.java
@@ -1,0 +1,13 @@
+package org.controlcenter.geoinfo.domain;
+
+public enum GpsStatus {
+	A("정상"),
+	V("비정상"),
+	O("미장착");
+
+	private String description;
+
+	GpsStatus(String description) {
+		this.description = description;
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/geoinfo/infrastructure/jpa/CycleInfoJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/geoinfo/infrastructure/jpa/CycleInfoJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.geoinfo.infrastructure.jpa;
+
+import org.controlcenter.geoinfo.infrastructure.jpa.entity.CycleInfoEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CycleInfoJpaRepository extends JpaRepository<CycleInfoEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/geoinfo/infrastructure/jpa/entity/CycleInfoEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/geoinfo/infrastructure/jpa/entity/CycleInfoEntity.java
@@ -1,0 +1,85 @@
+package org.controlcenter.geoinfo.infrastructure.jpa.entity;
+
+import java.io.Serial;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.controlcenter.geoinfo.domain.CycleInfo;
+import org.controlcenter.geoinfo.domain.GpsStatus;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "cycle_info")
+public class CycleInfoEntity {
+	@Serial
+	private static final long serialVersionUID = 1L;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "cycle_info_id")
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	private GpsStatus status;
+
+	private BigDecimal lat;
+
+	private BigDecimal lon;
+
+	private Integer ang;
+
+	private Integer spd;
+
+	private LocalDateTime intervalAt;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static CycleInfoEntity from(CycleInfo cycleInfo) {
+		CycleInfoEntity cycleInfoEntity = new CycleInfoEntity();
+		cycleInfoEntity.id = cycleInfo.getId();
+		cycleInfoEntity.status = cycleInfo.getStatus();
+		cycleInfoEntity.lat = cycleInfo.getLat();
+		cycleInfoEntity.lon = cycleInfo.getLon();
+		cycleInfoEntity.ang = cycleInfo.getAng();
+		cycleInfoEntity.spd = cycleInfo.getSpd();
+		cycleInfoEntity.intervalAt = cycleInfo.getIntervalAt();
+		cycleInfoEntity.createdAt = cycleInfo.getCreatedAt();
+		cycleInfoEntity.updatedAt = cycleInfo.getUpdatedAt();
+		cycleInfoEntity.deletedAt = cycleInfo.getDeletedAt();
+		return cycleInfoEntity;
+	}
+
+	public CycleInfo toDomain() {
+		return CycleInfo.builder()
+			.id(id)
+			.status(status)
+			.lat(lat)
+			.lon(lon)
+			.ang(ang)
+			.spd(spd)
+			.intervalAt(intervalAt)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/history/domain/DrivingHistory.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/history/domain/DrivingHistory.java
@@ -1,0 +1,27 @@
+package org.controlcenter.history.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class DrivingHistory {
+	private Long id;
+	private Long vehicleId;
+	private Long departmentId;
+	private String driverEmail;
+	private Double initialOdometer;
+	private Double finalOdometer;
+	private Double drivingDistance;
+	private Double businessCommuteDistance;
+	private Double businessUsageDistance;
+	private Boolean isBusinessUse;
+	private LocalDateTime usedAt;
+	private LocalDateTime onTime;
+	private LocalDateTime offTime;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/history/infrastructure/jpa/DrivingHistoryJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/history/infrastructure/jpa/DrivingHistoryJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.history.infrastructure.jpa;
+
+import org.controlcenter.history.infrastructure.jpa.entity.DrivingHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DrivingHistoryJpaRepository extends JpaRepository<DrivingHistoryEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/history/infrastructure/jpa/entity/DrivingHistoryEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/history/infrastructure/jpa/entity/DrivingHistoryEntity.java
@@ -1,0 +1,101 @@
+package org.controlcenter.history.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.history.domain.DrivingHistory;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "driving_history")
+public class DrivingHistoryEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "driving_history_id")
+	private Long id;
+
+	private Long vehicleId;
+
+	private Long departmentId;
+
+	private String driverEmail;
+
+	private Double initialOdometer;
+
+	private Double finalOdometer;
+
+	private Double drivingDistance;
+
+	private Double businessCommuteDistance;
+
+	private Double businessUsageDistance;
+
+	private Boolean isBusinessUse;
+
+	private LocalDateTime usedAt;
+
+	private LocalDateTime onTime;
+
+	private LocalDateTime offTime;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static DrivingHistoryEntity from(DrivingHistory drivingHistory) {
+		DrivingHistoryEntity drivingHistoryEntity = new DrivingHistoryEntity();
+		drivingHistoryEntity.id = drivingHistory.getId();
+		drivingHistoryEntity.vehicleId = drivingHistory.getVehicleId();
+		drivingHistoryEntity.departmentId = drivingHistory.getDepartmentId();
+		drivingHistoryEntity.driverEmail = drivingHistory.getDriverEmail();
+		drivingHistoryEntity.initialOdometer = drivingHistory.getInitialOdometer();
+		drivingHistoryEntity.finalOdometer = drivingHistory.getFinalOdometer();
+		drivingHistoryEntity.drivingDistance = drivingHistory.getDrivingDistance();
+		drivingHistoryEntity.businessCommuteDistance = drivingHistory.getBusinessCommuteDistance();
+		drivingHistoryEntity.businessUsageDistance = drivingHistory.getBusinessUsageDistance();
+		drivingHistoryEntity.isBusinessUse = drivingHistory.getIsBusinessUse();
+		drivingHistoryEntity.usedAt = drivingHistory.getUsedAt();
+		drivingHistoryEntity.onTime = drivingHistory.getOnTime();
+		drivingHistoryEntity.offTime = drivingHistory.getOffTime();
+		drivingHistoryEntity.createdAt = drivingHistory.getCreatedAt();
+		drivingHistoryEntity.updatedAt = drivingHistory.getUpdatedAt();
+		drivingHistoryEntity.deletedAt = drivingHistory.getDeletedAt();
+		return drivingHistoryEntity;
+	}
+
+	public DrivingHistory toDomain() {
+		return DrivingHistory.builder()
+			.id(id)
+			.vehicleId(vehicleId)
+			.departmentId(departmentId)
+			.driverEmail(driverEmail)
+			.initialOdometer(initialOdometer)
+			.finalOdometer(finalOdometer)
+			.drivingDistance(drivingDistance)
+			.businessCommuteDistance(businessCommuteDistance)
+			.businessUsageDistance(businessUsageDistance)
+			.isBusinessUse(isBusinessUse)
+			.usedAt(usedAt)
+			.onTime(onTime)
+			.offTime(offTime)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/notice/domain/Notice.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/notice/domain/Notice.java
@@ -1,0 +1,18 @@
+package org.controlcenter.notice.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Notice {
+	private Long id;
+	private String title;
+	private String content;
+	private String imageUrl;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/notice/infrastructure/jpa/NoticeJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/notice/infrastructure/jpa/NoticeJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.notice.infrastructure.jpa;
+
+import org.controlcenter.notice.infrastructure.jpa.entity.NoticeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeJpaRepository extends JpaRepository<NoticeEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/notice/infrastructure/jpa/entity/NoticeEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/notice/infrastructure/jpa/entity/NoticeEntity.java
@@ -1,0 +1,65 @@
+package org.controlcenter.notice.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.notice.domain.Notice;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "notice")
+public class NoticeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notice_id")
+	private Long id;
+
+	private String title;
+
+	private String content;
+
+	private String imageUrl;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static NoticeEntity from(Notice notice) {
+		NoticeEntity noticeEntity = new NoticeEntity();
+		noticeEntity.id = notice.getId();
+		noticeEntity.title = notice.getTitle();
+		noticeEntity.content = notice.getContent();
+		noticeEntity.imageUrl = notice.getImageUrl();
+		noticeEntity.createdAt = notice.getCreatedAt();
+		noticeEntity.updatedAt = notice.getUpdatedAt();
+		noticeEntity.deletedAt = notice.getDeletedAt();
+		return noticeEntity;
+	}
+
+	public Notice toDomain() {
+		return Notice.builder()
+			.id(id)
+			.title(title)
+			.content(content)
+			.imageUrl(imageUrl)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEvent.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEvent.java
@@ -1,0 +1,18 @@
+package org.controlcenter.vehicle.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class VehicleEvent {
+	private Long id;
+	private Long vehicleId;
+	private VehicleEventType type;
+	private LocalDateTime eventAt;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEventType.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEventType.java
@@ -1,0 +1,6 @@
+package org.controlcenter.vehicle.domain;
+
+public enum VehicleEventType {
+	ON,
+	OFF
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleInformation.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleInformation.java
@@ -1,0 +1,22 @@
+package org.controlcenter.vehicle.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class VehicleInformation {
+	private Long id;
+	private Long vehicleTypeId;
+	private String mdn;
+	private String tid;
+	private Integer mid;
+	private Integer pv;
+	private Integer did;
+	private Integer sum;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleType.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleType.java
@@ -1,0 +1,16 @@
+package org.controlcenter.vehicle.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class VehicleType {
+	private Long id;
+	private String vehicleTypesName;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleEventJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleEventJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.vehicle.infrastructure.jpa;
+
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleEventEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VehicleEventJpaRepository extends JpaRepository<VehicleEventEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleInformationJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleInformationJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.vehicle.infrastructure.jpa;
+
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleInformationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VehicleInformationJpaRepository extends JpaRepository<VehicleInformationEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleTypesJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleTypesJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.vehicle.infrastructure.jpa;
+
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleTypeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VehicleTypesJpaRepository extends JpaRepository<VehicleTypeEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleEventEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleEventEntity.java
@@ -1,0 +1,69 @@
+package org.controlcenter.vehicle.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.vehicle.domain.VehicleEvent;
+import org.controlcenter.vehicle.domain.VehicleEventType;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "vehicle_event")
+public class VehicleEventEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "vehicle_event_id")
+	private Long id;
+
+	private Long vehicleId;
+
+	@Enumerated(value = EnumType.STRING)
+	private VehicleEventType type;
+
+	private LocalDateTime eventAt;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static VehicleEventEntity from(VehicleEvent vehicleEvent) {
+		VehicleEventEntity vehicleEventEntity = new VehicleEventEntity();
+		vehicleEventEntity.id = vehicleEvent.getId();
+		vehicleEventEntity.vehicleId = vehicleEvent.getVehicleId();
+		vehicleEventEntity.type = vehicleEvent.getType();
+		vehicleEventEntity.eventAt = vehicleEvent.getEventAt();
+		vehicleEventEntity.createdAt = vehicleEvent.getCreatedAt();
+		vehicleEventEntity.updatedAt = vehicleEvent.getUpdatedAt();
+		vehicleEventEntity.deletedAt = vehicleEvent.getDeletedAt();
+		return vehicleEventEntity;
+	}
+
+	public VehicleEvent toDomain() {
+		return VehicleEvent.builder()
+			.id(id)
+			.vehicleId(vehicleId)
+			.type(type)
+			.eventAt(eventAt)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleInformationEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleInformationEntity.java
@@ -1,0 +1,81 @@
+package org.controlcenter.vehicle.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.vehicle.domain.VehicleInformation;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "vehicle_information")
+public class VehicleInformationEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "vehicle_id")
+	private Long id;
+
+	private Long vehicleTypeId;
+
+	private String mdn;
+
+	private String tid;
+
+	private Integer mid;
+
+	private Integer pv;
+
+	private Integer did;
+
+	private Integer sum;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static VehicleInformationEntity from(VehicleInformation vehicleInformation) {
+		VehicleInformationEntity vehicleInformationEntity = new VehicleInformationEntity();
+		vehicleInformationEntity.id = vehicleInformation.getId();
+		vehicleInformationEntity.vehicleTypeId = vehicleInformation.getVehicleTypeId();
+		vehicleInformationEntity.mdn = vehicleInformation.getMdn();
+		vehicleInformationEntity.tid = vehicleInformation.getTid();
+		vehicleInformationEntity.mid = vehicleInformation.getMid();
+		vehicleInformationEntity.pv = vehicleInformation.getPv();
+		vehicleInformationEntity.did = vehicleInformation.getDid();
+		vehicleInformationEntity.sum = vehicleInformation.getSum();
+		vehicleInformationEntity.createdAt = vehicleInformation.getCreatedAt();
+		vehicleInformationEntity.updatedAt = vehicleInformation.getUpdatedAt();
+		vehicleInformationEntity.deletedAt = vehicleInformation.getDeletedAt();
+		return vehicleInformationEntity;
+	}
+
+	public VehicleInformation toDomain() {
+		return VehicleInformation.builder()
+			.id(id)
+			.vehicleTypeId(vehicleTypeId)
+			.mdn(mdn)
+			.tid(tid)
+			.mid(mid)
+			.pv(pv)
+			.did(did)
+			.sum(sum)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleTypeEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleTypeEntity.java
@@ -1,0 +1,57 @@
+package org.controlcenter.vehicle.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.vehicle.domain.VehicleType;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "vehicle_types")
+public class VehicleTypeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "vehicle_types_id")
+	private Long id;
+
+	private String vehicleTypesName;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static VehicleTypeEntity from(VehicleType vehicleType) {
+		VehicleTypeEntity vehicleTypeEntity = new VehicleTypeEntity();
+		vehicleTypeEntity.id = vehicleType.getId();
+		vehicleTypeEntity.vehicleTypesName = vehicleType.getVehicleTypesName();
+		vehicleTypeEntity.createdAt = vehicleType.getCreatedAt();
+		vehicleTypeEntity.updatedAt = vehicleType.getUpdatedAt();
+		vehicleTypeEntity.deletedAt = vehicleType.getDeletedAt();
+		return vehicleTypeEntity;
+	}
+
+	public VehicleType toDomain() {
+		return VehicleType.builder()
+			.id(id)
+			.vehicleTypesName(vehicleTypesName)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/resources/schema/init-schema.sql
+++ b/monicar-control-center/src/main/resources/schema/init-schema.sql
@@ -109,7 +109,7 @@ CREATE TABLE vehicle_event
 DROP TABLE IF EXISTS cycle_info;
 CREATE TABLE cycle_info
 (
-    `cycle_info_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
+    `cycle_info_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '주기정보 PK',
     `interval_at`   TIMESTAMP    NOT NULL COMMENT '발생시간',
     `status`        VARCHAR(100) NOT NULL COMMENT 'GPS 상태',
     `lat`           DECIMAL      NOT NULL COMMENT '위도 * 1000000 한값(소수점 6자리)',

--- a/monicar-control-center/src/main/resources/schema/init-schema.sql
+++ b/monicar-control-center/src/main/resources/schema/init-schema.sql
@@ -28,7 +28,7 @@ CREATE TABLE manager
     `manager_id`      BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '담당자 PK',
     `department_id`   BIGINT       NOT NULL COMMENT '부서 PK',
     `email`           VARCHAR(255) NOT NULL COMMENT '이메일',
-    `id`              VARCHAR(255) NOT NULL COMMENT '아이디',
+    `login_id`        VARCHAR(255) NOT NULL COMMENT '아이디',
     `password`        VARCHAR(255) NOT NULL COMMENT '비밀번호',
     `nickname`        VARCHAR(255) NOT NULL COMMENT '닉네임',
     `role`            VARCHAR(255) NOT NULL COMMENT '권한',
@@ -39,10 +39,10 @@ CREATE TABLE manager
 ) ENGINE = InnoDB COMMENT ='담당자';
 
 
-DROP TABLE IF EXISTS alert;
-CREATE TABLE alert
+DROP TABLE IF EXISTS alarm;
+CREATE TABLE alarm
 (
-    `alert_id`    BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '알림 PK',
+    `alarm_id`    BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '알림 PK',
     `manager_id`  BIGINT       NOT NULL COMMENT '담당자 PK',
     `description` TEXT         NOT NULL COMMENT '알림 내용',
     `status`      VARCHAR(100) NOT NULL COMMENT '알림 상태',
@@ -68,17 +68,17 @@ CREATE TABLE notice
 DROP TABLE IF EXISTS vehicle_information;
 CREATE TABLE vehicle_information
 (
-    `vehicle_id`       BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
-    `vehicle_types_id` BIGINT       NOT NULL COMMENT '차종 PK',
-    `mdn`              VARCHAR(255) NOT NULL COMMENT '차량번호',
-    `tid`              VARCHAR(100) NOT NULL COMMENT '터미널 아이디',
-    `mid`              INT          NOT NULL COMMENT '제조사 아이디',
-    `pv`               INT          NOT NULL COMMENT '패킷버전',
-    `did`              INT          NOT NULL COMMENT '디바이스 아이디',
-    `sum`              INT          NOT NULL COMMENT '누적 주행 거리',
-    `created_at`       TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
-    `updated_at`       TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
-    `deleted_at`       TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
+    `vehicle_id`      BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
+    `vehicle_type_id` BIGINT       NOT NULL COMMENT '차종 PK',
+    `mdn`             VARCHAR(255) NOT NULL COMMENT '차량번호',
+    `tid`             VARCHAR(100) NOT NULL COMMENT '터미널 아이디',
+    `mid`             INT          NOT NULL COMMENT '제조사 아이디',
+    `pv`              INT          NOT NULL COMMENT '패킷버전',
+    `did`             INT          NOT NULL COMMENT '디바이스 아이디',
+    `sum`             INT          NOT NULL COMMENT '누적 주행 거리',
+    `created_at`      TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
+    `updated_at`      TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
+    `deleted_at`      TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
 ) ENGINE = InnoDB COMMENT ='차량정보';
 
 
@@ -96,28 +96,29 @@ CREATE TABLE vehicle_types
 DROP TABLE IF EXISTS vehicle_event;
 CREATE TABLE vehicle_event
 (
-    `vehicle_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
-    `type`       VARCHAR(100) NOT NULL COMMENT '이벤트 타입',
-    `event_at`   TIMESTAMP    NOT NULL COMMENT '발생 시간',
-    `created_at` TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
-    `updated_at` TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
-    `deleted_at` TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
+    `vehicle_event_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 이벤트 PK',
+    `vehicle_id`       BIGINT       NOT NULL COMMENT '차량 PK',
+    `type`             VARCHAR(100) NOT NULL COMMENT '이벤트 타입',
+    `event_at`         TIMESTAMP    NOT NULL COMMENT '발생 시간',
+    `created_at`       TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
+    `updated_at`       TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
+    `deleted_at`       TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
 ) ENGINE = InnoDB COMMENT ='차량 이벤트';
 
 
-DROP TABLE IF EXISTS gps_information;
-CREATE TABLE gps_information
+DROP TABLE IF EXISTS cycle_info;
+CREATE TABLE cycle_info
 (
-    `vehicle_id`  BIGINT       NOT NULL COMMENT '차량 PK',
-    `interval_at` TIMESTAMP    NOT NULL COMMENT '발생시간',
-    `status`      VARCHAR(100) NOT NULL COMMENT 'GPS 상태',
-    `lat`         DECIMAL      NOT NULL COMMENT '위도 * 1000000 한값(소수점 6자리)',
-    `lon`         DECIMAL      NOT NULL COMMENT '경도 * 1000000 한값(소수점 6자리)',
-    `ang`         INT          NOT NULL COMMENT '방향 - 범위 : 0 ~ 365',
-    `spd`         INT          NOT NULL COMMENT '속도 - 범위 : 0~ 255(단위: km/h)',
-    `created_at`  TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
-    `updated_at`  TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
-    `deleted_at`  TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
+    `cycle_info_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
+    `interval_at`   TIMESTAMP    NOT NULL COMMENT '발생시간',
+    `status`        VARCHAR(100) NOT NULL COMMENT 'GPS 상태',
+    `lat`           DECIMAL      NOT NULL COMMENT '위도 * 1000000 한값(소수점 6자리)',
+    `lon`           DECIMAL      NOT NULL COMMENT '경도 * 1000000 한값(소수점 6자리)',
+    `ang`           INT          NOT NULL COMMENT '방향 - 범위 : 0 ~ 365',
+    `spd`           INT          NOT NULL COMMENT '속도 - 범위 : 0~ 255(단위: km/h)',
+    `created_at`    TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
+    `updated_at`    TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
+    `deleted_at`    TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
 ) ENGINE = InnoDB COMMENT ='주기 정보';
 
 
@@ -127,7 +128,7 @@ CREATE TABLE driving_history
     `driving_history_id`        BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '운행내역 PK',
     `vehicle_id`                BIGINT       NOT NULL COMMENT '차량 PK',
     `department_id`             BIGINT       NULL COMMENT '부서 PK',
-    `is_business_use`           VARCHAR(100) NOT NULL COMMENT '업무용 확인',
+    `is_business_use`           TINYINT(1)   NOT NULL COMMENT '업무용인지 확인',
     `driver_email`              VARCHAR(255) NOT NULL COMMENT '운전자 이메일',
     `used_at`                   TIMESTAMP    NOT NULL COMMENT '사용일자',
     `initial_odometer`          DOUBLE       NOT NULL COMMENT '주행 전 계기판의 거리(km)',

--- a/monicar-control-center/src/test/java/org/controlcenter/jpa/JpaTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/jpa/JpaTest.java
@@ -1,0 +1,425 @@
+package org.controlcenter.jpa;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.controlcenter.alarm.domain.Alarm;
+import org.controlcenter.alarm.domain.AlarmStatus;
+import org.controlcenter.alarm.infrastructure.jpa.AlarmJpaRepository;
+import org.controlcenter.alarm.infrastructure.jpa.entity.AlarmEntity;
+import org.controlcenter.company.domain.Company;
+import org.controlcenter.company.domain.Department;
+import org.controlcenter.company.domain.Manager;
+import org.controlcenter.company.domain.Role;
+import org.controlcenter.company.infrastructure.jpa.CompanyJpaRepository;
+import org.controlcenter.company.infrastructure.jpa.DepartmentJpaRepository;
+import org.controlcenter.company.infrastructure.jpa.ManagerJpaRepository;
+import org.controlcenter.company.infrastructure.jpa.entity.CompanyEntity;
+import org.controlcenter.company.infrastructure.jpa.entity.DepartmentEntity;
+import org.controlcenter.company.infrastructure.jpa.entity.ManagerEntity;
+import org.controlcenter.geoinfo.domain.CycleInfo;
+import org.controlcenter.geoinfo.domain.GpsStatus;
+import org.controlcenter.geoinfo.infrastructure.jpa.CycleInfoJpaRepository;
+import org.controlcenter.geoinfo.infrastructure.jpa.entity.CycleInfoEntity;
+import org.controlcenter.history.domain.DrivingHistory;
+import org.controlcenter.history.infrastructure.jpa.DrivingHistoryJpaRepository;
+import org.controlcenter.history.infrastructure.jpa.entity.DrivingHistoryEntity;
+import org.controlcenter.notice.domain.Notice;
+import org.controlcenter.notice.infrastructure.jpa.NoticeJpaRepository;
+import org.controlcenter.notice.infrastructure.jpa.entity.NoticeEntity;
+import org.controlcenter.vehicle.domain.VehicleEvent;
+import org.controlcenter.vehicle.domain.VehicleEventType;
+import org.controlcenter.vehicle.domain.VehicleInformation;
+import org.controlcenter.vehicle.domain.VehicleType;
+import org.controlcenter.vehicle.infrastructure.jpa.VehicleEventJpaRepository;
+import org.controlcenter.vehicle.infrastructure.jpa.VehicleInformationJpaRepository;
+import org.controlcenter.vehicle.infrastructure.jpa.VehicleTypesJpaRepository;
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleEventEntity;
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleInformationEntity;
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleTypeEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[infrastructure 테스트] JPA 연결 테스트")
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class JpaTest {
+
+	@Autowired
+	private AlarmJpaRepository alarmJpaRepository;
+
+	@Autowired
+	private CompanyJpaRepository companyJpaRepository;
+
+	@Autowired
+	private DepartmentJpaRepository departmentJpaRepository;
+
+	@Autowired
+	private ManagerJpaRepository managerJpaRepository;
+
+	@Autowired
+	private CycleInfoJpaRepository cycleInfoJpaRepository;
+
+	@Autowired
+	private DrivingHistoryJpaRepository drivingHistoryJpaRepository;
+
+	@Autowired
+	private NoticeJpaRepository noticeJpaRepository;
+
+	@Autowired
+	private VehicleEventJpaRepository vehicleEventJpaRepository;
+
+	@Autowired
+	private VehicleInformationJpaRepository vehicleInformationJpaRepository;
+
+	@Autowired
+	private VehicleTypesJpaRepository vehicleTypesJpaRepository;
+
+	@DisplayName("AlarmEntity 테스트")
+	@Test
+	void AlarmEntityTest() {
+		// given
+		Alarm alarm = Alarm.builder()
+			.managerId(100L)
+			.description("test description")
+			.status(AlarmStatus.CHECKED)
+			.deletedAt(null)
+			.build();
+		alarmJpaRepository.save(AlarmEntity.from(alarm));
+
+		// when
+		List<Alarm> Alarms = alarmJpaRepository.findAll().stream()
+			.map(AlarmEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(Alarms).hasSize(1);
+
+		Alarm savedAlarm = Alarms.getFirst();
+
+		assertAll(
+			() -> assertThat(savedAlarm.getId()).isNotNull(),
+			() -> assertThat(savedAlarm.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedAlarm.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedAlarm.getManagerId()).isEqualTo(100L),
+			() -> assertThat(savedAlarm.getDescription()).isEqualTo("test description"),
+			() -> assertThat(savedAlarm.getStatus()).isEqualTo(AlarmStatus.CHECKED)
+		);
+	}
+
+	@DisplayName("CompanyEntity 테스트")
+	@Test
+	void CompanyEntityTest() {
+		// given
+		Company company = Company.builder()
+			.companyName("test company name")
+			.businessRegistrationNumber("999")
+			.deletedAt(null)
+			.build();
+		companyJpaRepository.save(CompanyEntity.from(company));
+
+		// when
+		List<Company> Companies = companyJpaRepository.findAll().stream()
+			.map(CompanyEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(Companies).hasSize(1);
+
+		Company savedCompany = Companies.getFirst();
+
+		assertAll(
+			() -> assertThat(savedCompany.getId()).isNotNull(),
+			() -> assertThat(savedCompany.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedCompany.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedCompany.getCompanyName()).isEqualTo("test company name"),
+			() -> assertThat(savedCompany.getBusinessRegistrationNumber()).isEqualTo("999")
+		);
+	}
+
+	@DisplayName("DepartmentEntity 테스트")
+	@Test
+	void DepartmentEntityTest() {
+		// given
+		Department department = Department.builder()
+			.companyId(999L)
+			.departmentName("test department")
+			.deletedAt(null)
+			.build();
+		departmentJpaRepository.save(DepartmentEntity.from(department));
+
+		// when
+		List<Department> Departments = departmentJpaRepository.findAll().stream()
+			.map(DepartmentEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(Departments).hasSize(1);
+
+		Department savedDepartment = Departments.getFirst();
+
+		assertAll(
+			() -> assertThat(savedDepartment.getId()).isNotNull(),
+			() -> assertThat(savedDepartment.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedDepartment.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedDepartment.getCompanyId()).isEqualTo(999L),
+			() -> assertThat(savedDepartment.getDepartmentName()).isEqualTo("test department")
+		);
+	}
+
+	@DisplayName("ManagerEntity 테스트")
+	@Test
+	void ManagerEntityTest() {
+		// given
+		Manager manager = Manager.builder()
+			.departmentId(999L)
+			.email("test email")
+			.loginId("test login id")
+			.password("test password")
+			.nickname("test nickname")
+			.role(Role.ROLE_ADMIN)
+			.lastLoginedAt(LocalDateTime.now())
+			.deletedAt(null)
+			.build();
+		managerJpaRepository.save(ManagerEntity.from(manager));
+
+		// when
+		List<Manager> managers = managerJpaRepository.findAll().stream()
+			.map(ManagerEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(managers).hasSize(1);
+
+		Manager savedManager = managers.getFirst();
+
+		assertAll(
+			() -> assertThat(savedManager.getId()).isNotNull(),
+			() -> assertThat(savedManager.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedManager.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedManager.getDepartmentId()).isEqualTo(999L),
+			() -> assertThat(savedManager.getEmail()).isEqualTo("test email")
+		);
+	}
+
+	@DisplayName("NoticeEntity 테스트")
+	@Test
+	void NoticeEntityTest() {
+		// given
+		Notice notice = Notice.builder()
+			.title("test title")
+			.content("test content")
+			.imageUrl("test image url")
+			.deletedAt(null)
+			.build();
+		noticeJpaRepository.save(NoticeEntity.from(notice));
+
+		// when
+		List<Notice> notices = noticeJpaRepository.findAll().stream()
+			.map(NoticeEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(notices).hasSize(1);
+
+		Notice savedNotice = notices.getFirst();
+
+		assertAll(
+			() -> assertThat(savedNotice.getId()).isNotNull(),
+			() -> assertThat(savedNotice.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedNotice.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedNotice.getTitle()).isEqualTo("test title"),
+			() -> assertThat(savedNotice.getContent()).isEqualTo("test content"),
+			() -> assertThat(savedNotice.getImageUrl()).isEqualTo("test image url")
+		);
+	}
+
+	@DisplayName("VehicleTypeEntity 테스트")
+	@Test
+	void VehicleTypeEntityTest() {
+		// given
+		VehicleType vehicleType = VehicleType.builder()
+			.vehicleTypesName("test vehicle types name")
+			.deletedAt(null)
+			.build();
+		vehicleTypesJpaRepository.save(VehicleTypeEntity.from(vehicleType));
+
+		// when
+		List<VehicleType> vehicleTypes = vehicleTypesJpaRepository.findAll().stream()
+			.map(VehicleTypeEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(vehicleTypes).hasSize(1);
+
+		VehicleType savedVehicleType = vehicleTypes.getFirst();
+
+		assertAll(
+			() -> assertThat(savedVehicleType.getId()).isNotNull(),
+			() -> assertThat(savedVehicleType.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleType.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleType.getVehicleTypesName()).isEqualTo("test vehicle types name")
+		);
+	}
+
+	@DisplayName("CycleInfoEntity 테스트")
+	@Test
+	void CycleInfoEntityTest() {
+		// given
+		CycleInfo cycleInfo = CycleInfo.builder()
+			.status(GpsStatus.A)
+			.lat(BigDecimal.ONE)
+			.lon(BigDecimal.ONE)
+			.ang(999)
+			.spd(999)
+			.intervalAt(LocalDateTime.now())
+			.deletedAt(null)
+			.build();
+		cycleInfoJpaRepository.save(CycleInfoEntity.from(cycleInfo));
+
+		// when
+		List<CycleInfo> cycleInfos = cycleInfoJpaRepository.findAll().stream()
+			.map(CycleInfoEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(cycleInfos).hasSize(1);
+
+		CycleInfo savedCycleInfo = cycleInfos.getFirst();
+
+		assertAll(
+			() -> assertThat(savedCycleInfo.getId()).isNotNull(),
+			() -> assertThat(savedCycleInfo.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedCycleInfo.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedCycleInfo.getStatus()).isEqualTo(GpsStatus.A),
+			() -> assertThat(savedCycleInfo.getLat()).isEqualTo(BigDecimal.ONE),
+			() -> assertThat(savedCycleInfo.getLon()).isEqualTo(BigDecimal.ONE),
+			() -> assertThat(savedCycleInfo.getAng()).isEqualTo(999),
+			() -> assertThat(savedCycleInfo.getSpd()).isEqualTo(999)
+		);
+	}
+
+	@DisplayName("VehicleInformationEntity 테스트")
+	@Test
+	void VehicleInformationEntityTest() {
+		// given
+		VehicleInformation vehicleInformation = VehicleInformation.builder()
+			.vehicleTypeId(999L)
+			.mdn("test mdn")
+			.tid("test tid")
+			.mid(999)
+			.pv(999)
+			.did(999)
+			.sum(999)
+			.deletedAt(null)
+			.build();
+		vehicleInformationJpaRepository.save(VehicleInformationEntity.from(vehicleInformation));
+
+		// when
+		List<VehicleInformation> vehicleInformations = vehicleInformationJpaRepository.findAll().stream()
+			.map(VehicleInformationEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(vehicleInformations).hasSize(1);
+
+		VehicleInformation savedVehicleInformation = vehicleInformations.getFirst();
+
+		assertAll(
+			() -> assertThat(savedVehicleInformation.getId()).isNotNull(),
+			() -> assertThat(savedVehicleInformation.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleInformation.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleInformation.getMdn()).isEqualTo("test mdn"),
+			() -> assertThat(savedVehicleInformation.getTid()).isEqualTo("test tid"),
+			() -> assertThat(savedVehicleInformation.getMid()).isEqualTo(999),
+			() -> assertThat(savedVehicleInformation.getPv()).isEqualTo(999),
+			() -> assertThat(savedVehicleInformation.getDid()).isEqualTo(999),
+			() -> assertThat(savedVehicleInformation.getSum()).isEqualTo(999)
+		);
+	}
+
+	@DisplayName("VehicleEventEntity 테스트")
+	@Test
+	void VehicleEventEntityTest() {
+		// given
+		VehicleEvent vehicleEvent = VehicleEvent.builder()
+			.vehicleId(999L)
+			.type(VehicleEventType.ON)
+			.eventAt(LocalDateTime.now())
+			.deletedAt(null)
+			.build();
+		vehicleEventJpaRepository.save(VehicleEventEntity.from(vehicleEvent));
+
+		// when
+		List<VehicleEvent> vehicleEvents = vehicleEventJpaRepository.findAll().stream()
+			.map(VehicleEventEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(vehicleEvents).hasSize(1);
+
+		VehicleEvent savedVehicleEvent = vehicleEvents.getFirst();
+
+		assertAll(
+			() -> assertThat(savedVehicleEvent.getId()).isNotNull(),
+			() -> assertThat(savedVehicleEvent.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleEvent.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleEvent.getVehicleId()).isEqualTo(999L),
+			() -> assertThat(savedVehicleEvent.getType()).isEqualTo(VehicleEventType.ON)
+		);
+	}
+
+	@DisplayName("DrivingHistoryEntity 테스트")
+	@Test
+	void DrivingHistoryEntityTest() {
+		// given
+		DrivingHistory drivingHistory = DrivingHistory.builder()
+			.vehicleId(999L)
+			.departmentId(999L)
+			.driverEmail("test driver email")
+			.initialOdometer(100.0)
+			.finalOdometer(100.0)
+			.drivingDistance(100.0)
+			.businessCommuteDistance(100.0)
+			.businessUsageDistance(100.0)
+			.isBusinessUse(true)
+			.usedAt(LocalDateTime.now())
+			.onTime(LocalDateTime.now())
+			.offTime(LocalDateTime.now())
+			.deletedAt(null)
+			.build();
+		drivingHistoryJpaRepository.save(DrivingHistoryEntity.from(drivingHistory));
+
+		// when
+		List<DrivingHistory> drivingHistories = drivingHistoryJpaRepository.findAll().stream()
+			.map(DrivingHistoryEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(drivingHistories).hasSize(1);
+
+		DrivingHistory savedDrivingHistory = drivingHistories.getFirst();
+
+		assertAll(
+			() -> assertThat(savedDrivingHistory.getId()).isNotNull(),
+			() -> assertThat(savedDrivingHistory.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedDrivingHistory.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedDrivingHistory.getDriverEmail()).isEqualTo("test driver email"),
+			() -> assertThat(savedDrivingHistory.getInitialOdometer()).isEqualTo(100.0),
+			() -> assertThat(savedDrivingHistory.getFinalOdometer()).isEqualTo(100.0),
+			() -> assertThat(savedDrivingHistory.getDrivingDistance()).isEqualTo(100.0),
+			() -> assertThat(savedDrivingHistory.getBusinessCommuteDistance()).isEqualTo(100.0),
+			() -> assertThat(savedDrivingHistory.getBusinessUsageDistance()).isEqualTo(100.0),
+			() -> assertThat(savedDrivingHistory.getIsBusinessUse()).isEqualTo(true)
+		);
+	}
+}

--- a/monicar-control-center/src/test/resources/application-test.yml
+++ b/monicar-control-center/src/test/resources/application-test.yml
@@ -2,6 +2,7 @@ spring:
   datasource:
     url: jdbc:tc:mysql:8.0.36:///?useSSL=false&serverTimezone=Asia/Seoul
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+
   jpa:
     show-sql: true
     properties:

--- a/monicar-control-center/src/test/resources/application-test.yml
+++ b/monicar-control-center/src/test/resources/application-test.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:tc:mysql:8.0.36:///?useSSL=false&serverTimezone=Asia/Seoul
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    hibernate:
+      ddl-auto: none
+
+  test:
+    database:
+      replace: none
+
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:/schema/init-schema.sql


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

> 테이블 엔티티 & 엔티티와 맵핑되는 도메인 객체를 정의
> JPA 엔티티와 테이블 연결 확인을 위한 테스트 작성

## #️⃣ 연관된 이슈

#53 

## 💡 리뷰어에게 하고 싶은 말

- ERD 수정에 따른 테이블 DDL 을 수정하였습니다.
    - 테이블 변경 관리를 하고 있지 않아서, 각자 로컬 환경 테이블을 한번 삭제해주시고 monicar-control-center 를 실행시켜 테이블을 새로고침 해주세요
- 엔티티과 각 엔티티에 맵핑되는 도메인 객체를 정의했습니다.
- JPA 엔티티와 테이블의 연동을 확인하기 위헤 연결 테스트를 작성했습니다.
    - 테스트를 위해 테스트 컨테이너를 MySQL 용으로 정의하였고 한번씩 테스트 돌려서 확인해보면 좋을 것 같습니다.
    - 주의 : 테스트할 때 docker 가 구동되어있어야 합니다. 
- Entity 에서 중복되는 코드를 BaseEntity로 분리하지 않았습니다(아직은요!)
- JPA 테스트에서 `@DataJpaTest` 말고 `@SpringBootTest`를 사용하였습니다.
    - 1. 통합테스트와 함께 최적화하기 좋음
    - 2. `@DataJpaTest` 를 사용하면 별도로 JPA 관련 Bean 들을 띄울 수 있도록 설정을 추가해야함(추가 작업 필요) 

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인