### PR TITLE
feat: 업체 생성 api 개발

### DIFF
--- a/monicar-control-center/build.gradle
+++ b/monicar-control-center/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
+    implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ErrorCode.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
 	INVALID_TYPE_VALUE(1005, "잘못된 유형 값을 입력하였습니다."),
 	HANDLE_ACCESS_DENIED(1006, "액세스가 거부되었습니다."),
 	FORBIDDEN_ACCESS(1007, "비정상적 접근입니다."),
-	EMPTY_PATH_VARIABLE(1008, "필수 경로 변수가 누락되었습니다. 요청 경로에 올바른 값을 입력해 주세요.");
+	EMPTY_PATH_VARIABLE(1008, "필수 경로 변수가 누락되었습니다. 요청 경로에 올바른 값을 입력해 주세요."),
+	ENTITY_ALREADY_EXIST(1009, "이미 존재하는 엔티티 입니다.");
 
 	private final int code;
 	private final String message;

--- a/monicar-control-center/src/main/java/org/controlcenter/company/application/CompanyService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/application/CompanyService.java
@@ -1,0 +1,29 @@
+package org.controlcenter.company.application;
+
+import java.util.Optional;
+
+import org.controlcenter.company.application.port.CompanyRepository;
+import org.controlcenter.company.domain.Company;
+import org.controlcenter.company.domain.CompanyCreate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class CompanyService {
+	private final CompanyRepository companyRepository;
+
+	@Transactional
+	public Company register(CompanyCreate command) {
+		Company company = Company.create(command);
+
+		return companyRepository.save(company);
+	}
+
+	private Optional<Company> findByCompanyName(String companyName) {
+		return companyRepository.findByCompanyName(companyName);
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/application/CompanyService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/application/CompanyService.java
@@ -1,7 +1,7 @@
 package org.controlcenter.company.application;
 
-import java.util.Optional;
-
+import org.controlcenter.common.exception.BusinessException;
+import org.controlcenter.common.response.code.ErrorCode;
 import org.controlcenter.company.application.port.CompanyRepository;
 import org.controlcenter.company.domain.Company;
 import org.controlcenter.company.domain.CompanyCreate;
@@ -18,12 +18,16 @@ public class CompanyService {
 
 	@Transactional
 	public Company register(CompanyCreate command) {
-		Company company = Company.create(command);
+		validateAlreadyExistCompanyName(command.getCompanyName());
 
-		return companyRepository.save(company);
+		return companyRepository.save(Company.create(command));
 	}
 
-	private Optional<Company> findByCompanyName(String companyName) {
-		return companyRepository.findByCompanyName(companyName);
+	private void validateAlreadyExistCompanyName(String companyName) {
+		companyRepository.findByCompanyName(companyName)
+			.ifPresent(existCompany -> {
+				throw new BusinessException(ErrorCode.ENTITY_ALREADY_EXIST);
+			});
 	}
+
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/company/application/port/CompanyRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/application/port/CompanyRepository.java
@@ -1,0 +1,11 @@
+package org.controlcenter.company.application.port;
+
+import java.util.Optional;
+
+import org.controlcenter.company.domain.Company;
+
+public interface CompanyRepository {
+	Company save(Company company);
+
+	Optional<Company> findByCompanyName(String companyName);
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/Company.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/Company.java
@@ -1,9 +1,9 @@
 package org.controlcenter.company.domain;
 
-import java.time.LocalDateTime;
-
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
@@ -14,4 +14,11 @@ public class Company {
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 	private LocalDateTime deletedAt;
+
+    public static Company create(CompanyCreate companyCreate) {
+        return Company.builder()
+                .companyName(companyCreate.getCompanyName())
+                .businessRegistrationNumber(companyCreate.getBusinessRegistrationNumber())
+                .build();
+    }
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/CompanyCreate.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/CompanyCreate.java
@@ -1,0 +1,42 @@
+package org.controlcenter.company.domain;
+
+import org.controlcenter.common.exception.BusinessException;
+import org.controlcenter.common.response.code.ErrorCode;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CompanyCreate {
+	public static final int MAX_COMPANY_SIZE = 10;
+
+	private final String companyName;
+	private final String businessRegistrationNumber;
+
+	private CompanyCreate(
+		String companyName,
+		String businessRegistrationNumber
+	) {
+		this.companyName = companyName;
+		this.businessRegistrationNumber = businessRegistrationNumber;
+	}
+
+	public static CompanyCreate of(
+		String companyName,
+		String businessRegistrationNumber
+	) {
+		validateCompanyNameSize(companyName);
+
+		return new CompanyCreate(
+			companyName,
+			businessRegistrationNumber
+		);
+	}
+
+	private static void validateCompanyNameSize(String companyName) {
+		if (companyName.length() > MAX_COMPANY_SIZE) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyJpaRepository.java
@@ -1,7 +1,11 @@
 package org.controlcenter.company.infrastructure.jpa;
 
+import org.controlcenter.company.domain.Company;
 import org.controlcenter.company.infrastructure.jpa.entity.CompanyEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CompanyJpaRepository extends JpaRepository<CompanyEntity, Long> {
+    Optional<Company> findByCompanyName(String companyName);
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyRepositoryAdapter.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyRepositoryAdapter.java
@@ -1,0 +1,27 @@
+package org.controlcenter.company.infrastructure.jpa;
+
+import java.util.Optional;
+
+import org.controlcenter.company.application.port.CompanyRepository;
+import org.controlcenter.company.domain.Company;
+import org.controlcenter.company.infrastructure.jpa.entity.CompanyEntity;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class CompanyRepositoryAdapter implements CompanyRepository {
+	private final CompanyJpaRepository companyJpaRepository;
+
+	@Override
+	public Company save(Company company) {
+		return companyJpaRepository.save(CompanyEntity.from(company))
+			.toDomain();
+	}
+
+	@Override
+	public Optional<Company> findByCompanyName(String companyName) {
+		return companyJpaRepository.findByCompanyName(companyName);
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/presentation/CompanyController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/presentation/CompanyController.java
@@ -1,0 +1,34 @@
+package org.controlcenter.company.presentation;
+
+import org.controlcenter.common.response.BaseResponse;
+import org.controlcenter.company.application.CompanyService;
+import org.controlcenter.company.presentation.dto.CompanyCreateRequest;
+import org.controlcenter.company.presentation.dto.SimpleCompanyResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/companies")
+public class CompanyController {
+	private final CompanyService companyService;
+
+	/**
+	 * 업체(회사) 등록 api
+	 *
+	 * @param companyCreateRequest 업체(회사) 등록 요청 데이터
+	 * @return 등록된 업체 데이터를 반환
+	 */
+	@PostMapping
+	public BaseResponse<SimpleCompanyResponse> register(
+		@Valid @RequestBody CompanyCreateRequest companyCreateRequest
+	) {
+		var company = companyService.register(companyCreateRequest.toDomain());
+		return BaseResponse.success(SimpleCompanyResponse.from(company));
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/presentation/dto/CompanyCreateRequest.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/presentation/dto/CompanyCreateRequest.java
@@ -1,0 +1,22 @@
+package org.controlcenter.company.presentation.dto;
+
+import org.controlcenter.company.domain.CompanyCreate;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record CompanyCreateRequest(
+	@NotBlank(message = "회사 이름은 null 또는 비어 있을 수 없습니다.")
+	String companyName,
+
+	@NotBlank(message = "회사 등록 번호는 null 또는 비어 있을 수 없습니다.")
+	String businessRegistrationNumber
+) {
+	public CompanyCreate toDomain() {
+		return CompanyCreate.of(
+			companyName,
+			businessRegistrationNumber
+		);
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/presentation/dto/SimpleCompanyResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/presentation/dto/SimpleCompanyResponse.java
@@ -1,0 +1,28 @@
+package org.controlcenter.company.presentation.dto;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.company.domain.Company;
+
+import lombok.Builder;
+
+@Builder
+public record SimpleCompanyResponse(
+	Long id,
+	String companyName,
+	String businessRegistrationNumber,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt,
+	LocalDateTime deletedAt
+) {
+	public static SimpleCompanyResponse from(Company company) {
+		return SimpleCompanyResponse.builder()
+			.id(company.getId())
+			.companyName(company.getCompanyName())
+			.businessRegistrationNumber(company.getBusinessRegistrationNumber())
+			.createdAt(company.getCreatedAt())
+			.updatedAt(company.getUpdatedAt())
+			.deletedAt(company.getDeletedAt())
+			.build();
+	}
+}

--- a/monicar-control-center/src/test/java/org/controlcenter/company/application/CompanyServiceTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/company/application/CompanyServiceTest.java
@@ -1,0 +1,51 @@
+package org.controlcenter.company.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.controlcenter.common.exception.BusinessException;
+import org.controlcenter.common.response.code.ErrorCode;
+import org.controlcenter.company.domain.Company;
+import org.controlcenter.company.domain.CompanyCreate;
+import org.controlcenter.company.infrastructure.jpa.CompanyJpaRepository;
+import org.controlcenter.company.infrastructure.jpa.entity.CompanyEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[service 통합테스트] CompanyService")
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CompanyServiceTest {
+
+	@Autowired
+	private CompanyService companyService;
+
+	@Autowired
+	private CompanyJpaRepository companyJpaRepository;
+
+	@DisplayName("이미 등록된 회사이름이 존재한다면, 새로 등록할 수 없다.")
+	@Test
+	void registerWithAlreadyExistsCompanyName() {
+		// given
+		Company company = Company.builder()
+			.companyName("company")
+			.businessRegistrationNumber("A001")
+			.build();
+		companyJpaRepository.save(CompanyEntity.from(company));
+
+		CompanyCreate companyCreate = CompanyCreate.builder()
+			.companyName("company")
+			.businessRegistrationNumber("A002")
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> companyService.register(companyCreate))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.ENTITY_ALREADY_EXIST);
+	}
+}

--- a/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyCreateTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyCreateTest.java
@@ -1,0 +1,45 @@
+package org.controlcenter.company.domain;
+
+import org.controlcenter.common.exception.BusinessException;
+import org.controlcenter.common.response.code.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("[domain 단위테스트] CompanyCreate")
+class CompanyCreateTest {
+
+	@DisplayName("회사를 생성할 수 있다.")
+	@Test
+	void createCompanyCreate() {
+		// given
+		String companyName = "company";
+		String businessRegistrationNumber = "A001";
+
+		// when
+		CompanyCreate companyCreate = CompanyCreate.of(companyName, businessRegistrationNumber);
+
+		// then
+		assertAll(
+			() -> assertThat(companyCreate.getCompanyName()).isEqualTo("company"),
+			() -> assertThat(companyCreate.getBusinessRegistrationNumber()).isEqualTo("A001")
+		);
+	}
+
+	@DisplayName("회사 이름이 10자 초과라면 생성할 수 없다.")
+	@Test
+	void createCompanyCreateWithInvalidCompanyName() {
+		// given
+		String invalidCompanyName = "a".repeat(11);
+		String businessRegistrationNumber = "A001";
+
+		// when & then
+		assertThatThrownBy(() -> CompanyCreate.of(invalidCompanyName, businessRegistrationNumber))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+	}
+}

--- a/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyTest.java
@@ -1,0 +1,25 @@
+package org.controlcenter.company.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DisplayName("[domain 단위테스트] Company")
+class CompanyTest {
+
+	@DisplayName("쿠폰을 생성할 수 있다.")
+	@Test
+	void createCoupon() {
+		// given
+		CompanyCreate companyCreate = CompanyCreate.builder()
+			.companyName("company")
+			.businessRegistrationNumber("A001")
+			.build();
+
+		// when & then
+		assertThatCode(() -> Company.create(companyCreate))
+			.doesNotThrowAnyException();
+	}
+
+}

--- a/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyTest.java
@@ -8,9 +8,9 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 @DisplayName("[domain 단위테스트] Company")
 class CompanyTest {
 
-	@DisplayName("쿠폰을 생성할 수 있다.")
+	@DisplayName("업체를 생성할 수 있다.")
 	@Test
-	void createCoupon() {
+	void createCompany() {
 		// given
 		CompanyCreate companyCreate = CompanyCreate.builder()
 			.companyName("company")

--- a/monicar-control-center/src/test/java/org/controlcenter/company/presentation/CompanyControllerTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/company/presentation/CompanyControllerTest.java
@@ -1,0 +1,134 @@
+package org.controlcenter.company.presentation;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import org.controlcenter.company.application.CompanyService;
+import org.controlcenter.company.domain.Company;
+import org.controlcenter.company.domain.CompanyCreate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@DisplayName("[controller 단위 테스트] CompanyController")
+@WebMvcTest(CompanyController.class)
+class CompanyControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private CompanyService companyService;
+
+	@DisplayName("업체(회사)를 등록할 수 있다.")
+	@Test
+	void register() throws Exception {
+		// given
+		CompanyCreate companyCreate = CompanyCreate.builder()
+			.companyName("company")
+			.businessRegistrationNumber("A001")
+			.build();
+
+		// stubbing
+		Company company = Company.builder()
+			.id(1L)
+			.companyName("company")
+			.businessRegistrationNumber("A001")
+			.createdAt(LocalDateTime.of(2024, 12, 1, 0, 0, 0))
+			.updatedAt(LocalDateTime.of(2024, 12, 1, 0, 0, 0))
+			.deletedAt(null)
+			.build();
+
+		when(companyService.register(any(CompanyCreate.class)))
+			.thenReturn(company);
+
+		// when
+		var result = mockMvc.perform(post("/v1/companies")
+			.content(objectMapper.writeValueAsString(companyCreate))
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result.andDo(print());
+		result.andExpect(status().isOk());
+	}
+
+	static Stream<Arguments> nullTestData() {
+		return Stream.of(
+			Arguments.of(null, "A001"),
+			Arguments.of("company", null)
+		);
+	}
+
+	@DisplayName("쿠폰 등록 요청 시 필드는 null 일 수 없다.")
+	@ParameterizedTest(name = "요청 필드 : {0}, {1}")
+	@MethodSource("nullTestData")
+	void registerCompanyWithNullRequestField(String companyName, String businessRegistrationNumber) throws Exception {
+		// given
+		CompanyCreate companyCreate = CompanyCreate.builder()
+			.companyName(companyName)
+			.businessRegistrationNumber(businessRegistrationNumber)
+			.build();
+
+		// when
+		var result = mockMvc.perform(post("/v1/companies")
+			.content(objectMapper.writeValueAsString(companyCreate))
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result.andDo(print());
+		result.andExpect(status().isOk());
+		result.andExpect(jsonPath("$.isSuccess").value(false));
+		result.andExpect(jsonPath("$.errorCode").value(1000));
+	}
+
+	static Stream<Arguments> emptyTestData() {
+		return Stream.of(
+			Arguments.of("", "A001"),
+			Arguments.of("  ", "A001"),
+			Arguments.of("company", ""),
+			Arguments.of("company", "  ")
+		);
+	}
+
+	@DisplayName("쿠폰 등록 요청 시 필드는 empty 일 수 없다.")
+	@ParameterizedTest(name = "요청 필드 : {0}, {1}")
+	@MethodSource("emptyTestData")
+	void registerCompanyWithEmptyRequestField(String companyName, String businessRegistrationNumber) throws Exception {
+		// given
+		CompanyCreate companyCreate = CompanyCreate.builder()
+			.companyName(companyName)
+			.businessRegistrationNumber(businessRegistrationNumber)
+			.build();
+
+		// when
+		var result = mockMvc.perform(post("/v1/companies")
+			.content(objectMapper.writeValueAsString(companyCreate))
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result.andDo(print());
+		result.andExpect(status().isOk());
+		result.andExpect(jsonPath("$.isSuccess").value(false));
+		result.andExpect(jsonPath("$.errorCode").value(1000));
+	}
+}


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

> 업체 등록 api 개발

## #️⃣ 연관된 이슈

#64 

## 💡 리뷰어에게 하고 싶은 말

- 금일 이야기된 내용들을 기반으로 전체적인 API 개발 참고용으로 업체 등록 API 만들었습니다. (참고용 일뿐입니다!)
  - deletedAt 를 활용해 softdelete 방식을 사용하고 있으므로, 실제 조회할때에는 `where deletedAt is not null` 등과 같이 활용해야 합니다.(현재는 편의상 그냥 조회했음)
- 컨트롤러 단위 테스트, 서비스 통합 테스트, 도메인 단위테스트 각각 참고용으로 구현했습니다.
	- 아래와 같이 계층별 책임을 고려해서 작성하였구, `팀 의견 종합에 따라` 테스트 형식은 언제든지 달라질 수 있습니다! 
	- 컨트롤러 : 요청 & 응답 & validation 에 대한 책임 -> 단위 테스트
	- 서비스 : 비즈니스 로직 + 데이터 저장 & 조회의 책임 -> 통합 테스트
	- 도메인 객체 : 객체지향적 관점의 도메인 클래스 내부 메서드의 비즈니스 로직 책임 -> 단위 테스트
- ✨ 금일 이야기된 내용들
    - controller 계층의 dto와 application 계층의 command 객체(여기서는 CompanyCreate)를 분리하기
        - dto 는 validation 책임, command 는 command 역할에 맞는 비즈니스 로직 책임
    - 인프라 계층은 인터페이스로 의존관계 역전시키기(결합도 낮추기)
    - 테스트는 어떤 부분의 어떠 책임을 테스트 할 것인지 아직 정하지 않았음
    - url 형식도 구체적으로 정하지 않았음(v1과 같이 버저닝을 할 것인가.. 등)
  
- ✨ 마지막 안건사항
    - Entity 필드를 class로 두어서 `@ManyToOne` 등을 적극 활용해 JPA를 조금 더 활용해보기(JPA 를 학습하거나 기능들을 적극적으로 써보고 싶으신 분들은 자유롭게 의견 주시면 좋겠습니다!)
        - 위와 관련해서 궁금하신 분들은 `JPA 직접참조/간접참조` 찾아보시면 될 것 같습니다!

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인