### PR TITLE
feat: 차량 정보 조회 API 구현

### DIFF
--- a/monicar-control-center/build.gradle
+++ b/monicar-control-center/build.gradle
@@ -1,10 +1,22 @@
 dependencies {
+    // spring
     implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
 
+    // mybatis
+    implementation "org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3"
+
+    // querydsl
+    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // test container
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:mysql")
 }
@@ -15,4 +27,25 @@ tasks.bootJar {
 
 tasks.jar {
     enabled = true
+}
+
+// querydsl : Q클래스를 자동으로 생성하고 관리하기 위한 빌드 설정
+def querydslDir = "${projectDir}/build/generated/querydsl"
+
+sourceSets {
+    main {
+        java {
+            srcDirs querydslDir
+        }
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+tasks.named("clean") {
+    doLast {
+        delete querydslDir
+    }
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/config/QuerydslConfig.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/config/QuerydslConfig.java
@@ -1,0 +1,17 @@
+package org.controlcenter.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class QuerydslConfig {
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/geoinfo/domain/CycleInfo.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/geoinfo/domain/CycleInfo.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 @Getter
 public class CycleInfo {
 	private long id;
+	private long vehicleId;
 	private GpsStatus status;
 	private BigDecimal lat;
 	private BigDecimal lon;

--- a/monicar-control-center/src/main/java/org/controlcenter/geoinfo/infrastructure/jpa/entity/CycleInfoEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/geoinfo/infrastructure/jpa/entity/CycleInfoEntity.java
@@ -32,6 +32,8 @@ public class CycleInfoEntity {
 	@Column(name = "cycle_info_id")
 	private Long id;
 
+	private Long vehicleId;
+
 	@Enumerated(EnumType.STRING)
 	private GpsStatus status;
 
@@ -56,6 +58,7 @@ public class CycleInfoEntity {
 	public static CycleInfoEntity from(CycleInfo cycleInfo) {
 		CycleInfoEntity cycleInfoEntity = new CycleInfoEntity();
 		cycleInfoEntity.id = cycleInfo.getId();
+		cycleInfoEntity.vehicleId = cycleInfo.getVehicleId();
 		cycleInfoEntity.status = cycleInfo.getStatus();
 		cycleInfoEntity.lat = cycleInfo.getLat();
 		cycleInfoEntity.lon = cycleInfo.getLon();
@@ -71,6 +74,7 @@ public class CycleInfoEntity {
 	public CycleInfo toDomain() {
 		return CycleInfo.builder()
 			.id(id)
+			.vehicleId(vehicleId)
 			.status(status)
 			.lat(lat)
 			.lon(lon)

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleInformation.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleInformation.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public class VehicleInformation {
 	private Long id;
 	private Long vehicleTypeId;
+	private String vehicleNumber;
 	private String mdn;
 	private String tid;
 	private Integer mid;

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
@@ -1,13 +1,10 @@
 package org.controlcenter.vehicle.infrastructure;
 
-import org.controlcenter.geoinfo.infrastructure.jpa.entity.QCycleInfoEntity;
-import org.controlcenter.vehicle.infrastructure.jpa.entity.QVehicleInformationEntity;
+import org.controlcenter.vehicle.infrastructure.mybatis.MyBatisVehicleInfoMapper;
 import org.controlcenter.vehicle.presentation.dto.VehicleInfoResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleInfoSearchRequest;
 import org.springframework.stereotype.Repository;
 
-import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -16,28 +13,9 @@ import lombok.RequiredArgsConstructor;
 @Repository
 public class VehicleQueryRepository {
 	private final JPAQueryFactory jpaQueryFactory;
+	private final MyBatisVehicleInfoMapper myBatisVehicleInfoMapper;
 
 	public VehicleInfoResponse getVehicleInfo(VehicleInfoSearchRequest request) {
-
-		QVehicleInformationEntity vehicleInformationEntity = QVehicleInformationEntity.vehicleInformationEntity;
-		QCycleInfoEntity cycleInfoEntity = QCycleInfoEntity.cycleInfoEntity;
-
-		JPAQuery<VehicleInfoResponse> query = jpaQueryFactory
-			.select(
-				Projections.fields(
-					VehicleInfoResponse.class,
-					vehicleInformationEntity.id.as("vehicleId"),
-					vehicleInformationEntity.vehicleNumber.as("vehicleNumber"),
-					vehicleInformationEntity.createdAt.as("fistDataAt")
-				)
-			)
-			.from(vehicleInformationEntity)
-			.where(
-				vehicleInformationEntity.vehicleNumber.eq(request.vehicleNumber()),
-				vehicleInformationEntity.deletedAt.isNull()
-			)
-			.fetchOne();
-
-		return null;
+		return myBatisVehicleInfoMapper.selectVehicleInfo(request.vehicleNumber());
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
@@ -1,0 +1,43 @@
+package org.controlcenter.vehicle.infrastructure;
+
+import org.controlcenter.geoinfo.infrastructure.jpa.entity.QCycleInfoEntity;
+import org.controlcenter.vehicle.infrastructure.jpa.entity.QVehicleInformationEntity;
+import org.controlcenter.vehicle.presentation.dto.VehicleInfoResponse;
+import org.controlcenter.vehicle.presentation.dto.VehicleInfoSearchRequest;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class VehicleQueryRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public VehicleInfoResponse getVehicleInfo(VehicleInfoSearchRequest request) {
+
+		QVehicleInformationEntity vehicleInformationEntity = QVehicleInformationEntity.vehicleInformationEntity;
+		QCycleInfoEntity cycleInfoEntity = QCycleInfoEntity.cycleInfoEntity;
+
+		JPAQuery<VehicleInfoResponse> query = jpaQueryFactory
+			.select(
+				Projections.fields(
+					VehicleInfoResponse.class,
+					vehicleInformationEntity.id.as("vehicleId"),
+					vehicleInformationEntity.vehicleNumber.as("vehicleNumber"),
+					vehicleInformationEntity.createdAt.as("fistDataAt")
+				)
+			)
+			.from(vehicleInformationEntity)
+			.where(
+				vehicleInformationEntity.vehicleNumber.eq(request.vehicleNumber()),
+				vehicleInformationEntity.deletedAt.isNull()
+			)
+			.fetchOne();
+
+		return null;
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleInformationEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleInformationEntity.java
@@ -27,6 +27,8 @@ public class VehicleInformationEntity {
 
 	private Long vehicleTypeId;
 
+	private String vehicleNumber;
+
 	private String mdn;
 
 	private String tid;
@@ -51,6 +53,7 @@ public class VehicleInformationEntity {
 		VehicleInformationEntity vehicleInformationEntity = new VehicleInformationEntity();
 		vehicleInformationEntity.id = vehicleInformation.getId();
 		vehicleInformationEntity.vehicleTypeId = vehicleInformation.getVehicleTypeId();
+		vehicleInformationEntity.vehicleNumber = vehicleInformation.getVehicleNumber();
 		vehicleInformationEntity.mdn = vehicleInformation.getMdn();
 		vehicleInformationEntity.tid = vehicleInformation.getTid();
 		vehicleInformationEntity.mid = vehicleInformation.getMid();
@@ -67,6 +70,7 @@ public class VehicleInformationEntity {
 		return VehicleInformation.builder()
 			.id(id)
 			.vehicleTypeId(vehicleTypeId)
+			.vehicleNumber(vehicleNumber)
 			.mdn(mdn)
 			.tid(tid)
 			.mid(mid)

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
@@ -1,0 +1,28 @@
+package org.controlcenter.vehicle.infrastructure.mybatis;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import org.controlcenter.vehicle.presentation.dto.VehicleInfoResponse;
+
+@Mapper
+public interface MyBatisVehicleInfoMapper {
+
+	@Select("""
+			select
+				vi.vehicle_id as vehicleId,
+				vi.vehicle_number as vehicleNumber,
+				vi.created_at as firstDataAt,
+				(
+					select ci.created_at
+					from cycle_info ci
+					where ci.vehicle_id = vi.vehicle_id
+					order by ci.interval_at DESC
+					limit 1
+				) as lastDataAt
+			from vehicle_information vi
+			where vi.vehicle_number = #{vehicleNumber}
+			  and vi.deleted_at is null;
+		""")
+	VehicleInfoResponse selectVehicleInfo(@Param("vehicleNumber") String vehicleNumber);
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
@@ -1,0 +1,27 @@
+package org.controlcenter.vehicle.presentation;
+
+import org.controlcenter.common.response.BaseResponse;
+import org.controlcenter.vehicle.infrastructure.VehicleQueryRepository;
+import org.controlcenter.vehicle.presentation.dto.VehicleInfoResponse;
+import org.controlcenter.vehicle.presentation.dto.VehicleInfoSearchRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("api/v1/vehicles")
+public class VehicleController {
+	private final VehicleQueryRepository vehicleQueryRepository;
+
+	@GetMapping
+	public BaseResponse<VehicleInfoResponse> getVehicleInfo(
+		@Valid VehicleInfoSearchRequest request
+	) {
+		var vehicleInfoResponse = vehicleQueryRepository.getVehicleInfo(request);
+		return BaseResponse.success(vehicleInfoResponse);
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleInfoResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleInfoResponse.java
@@ -1,0 +1,14 @@
+package org.controlcenter.vehicle.presentation.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+@Builder
+public record VehicleInfoResponse(
+	Long vehicleId,
+	String vehicleNumber,
+	LocalDateTime firstDataAt,
+	LocalDateTime lastDataAt
+) {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleInfoSearchRequest.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleInfoSearchRequest.java
@@ -1,0 +1,9 @@
+package org.controlcenter.vehicle.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record VehicleInfoSearchRequest(
+	@NotBlank(message = "차량 정보는 비어 있을 수 없습니다.")
+	String vehicleNumber
+) {
+}

--- a/monicar-control-center/src/main/resources/schema/init-schema.sql
+++ b/monicar-control-center/src/main/resources/schema/init-schema.sql
@@ -1,5 +1,4 @@
-DROP TABLE IF EXISTS company;
-CREATE TABLE company
+CREATE TABLE IF NOT EXISTS company
 (
     `company_id`                   BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '업체 PK',
     `company_name`                 VARCHAR(100) NOT NULL COMMENT '상호명',
@@ -10,8 +9,7 @@ CREATE TABLE company
 ) ENGINE = InnoDB COMMENT ='업체';
 
 
-DROP TABLE IF EXISTS department;
-CREATE TABLE department
+CREATE TABLE IF NOT EXISTS department
 (
     `department_id`   BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '부서 PK',
     `company_id`      BIGINT       NOT NULL COMMENT '업체 PK',
@@ -22,8 +20,7 @@ CREATE TABLE department
 ) ENGINE = InnoDB COMMENT ='부서';
 
 
-DROP TABLE IF EXISTS manager;
-CREATE TABLE manager
+CREATE TABLE IF NOT EXISTS manager
 (
     `manager_id`      BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '담당자 PK',
     `department_id`   BIGINT       NOT NULL COMMENT '부서 PK',
@@ -39,8 +36,7 @@ CREATE TABLE manager
 ) ENGINE = InnoDB COMMENT ='담당자';
 
 
-DROP TABLE IF EXISTS alarm;
-CREATE TABLE alarm
+CREATE TABLE IF NOT EXISTS alarm
 (
     `alarm_id`    BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '알림 PK',
     `manager_id`  BIGINT       NOT NULL COMMENT '담당자 PK',
@@ -52,8 +48,7 @@ CREATE TABLE alarm
 ) ENGINE = InnoDB COMMENT ='알림';
 
 
-DROP TABLE IF EXISTS notice;
-CREATE TABLE notice
+CREATE TABLE IF NOT EXISTS notice
 (
     `notice_id`  BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '공지사항 PK',
     `title`      VARCHAR(100) NOT NULL COMMENT '제목',
@@ -65,12 +60,12 @@ CREATE TABLE notice
 ) ENGINE = InnoDB COMMENT ='공지사항';
 
 
-DROP TABLE IF EXISTS vehicle_information;
-CREATE TABLE vehicle_information
+CREATE TABLE IF NOT EXISTS vehicle_information
 (
     `vehicle_id`      BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
     `vehicle_type_id` BIGINT       NOT NULL COMMENT '차종 PK',
-    `mdn`             VARCHAR(255) NOT NULL COMMENT '차량번호',
+    `vehicle_number`  VARCHAR(100) NOT NULL COMMENT '차량번호',
+    `mdn`             VARCHAR(255) NOT NULL COMMENT '차량식별값',
     `tid`             VARCHAR(100) NOT NULL COMMENT '터미널 아이디',
     `mid`             INT          NOT NULL COMMENT '제조사 아이디',
     `pv`              INT          NOT NULL COMMENT '패킷버전',
@@ -82,8 +77,7 @@ CREATE TABLE vehicle_information
 ) ENGINE = InnoDB COMMENT ='차량정보';
 
 
-DROP TABLE IF EXISTS vehicle_types;
-CREATE TABLE vehicle_types
+CREATE TABLE IF NOT EXISTS vehicle_types
 (
     `vehicle_types_id`   BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차종 PK',
     `vehicle_types_name` VARCHAR(255) NOT NULL COMMENT '차종명',
@@ -93,8 +87,7 @@ CREATE TABLE vehicle_types
 ) ENGINE = InnoDB COMMENT ='차종';
 
 
-DROP TABLE IF EXISTS vehicle_event;
-CREATE TABLE vehicle_event
+CREATE TABLE IF NOT EXISTS vehicle_event
 (
     `vehicle_event_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 이벤트 PK',
     `vehicle_id`       BIGINT       NOT NULL COMMENT '차량 PK',
@@ -106,10 +99,10 @@ CREATE TABLE vehicle_event
 ) ENGINE = InnoDB COMMENT ='차량 이벤트';
 
 
-DROP TABLE IF EXISTS cycle_info;
-CREATE TABLE cycle_info
+CREATE TABLE IF NOT EXISTS cycle_info
 (
     `cycle_info_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '주기정보 PK',
+    `vehicle_id`    BIGINT       NOT NULL COMMENT '차량 PK',
     `interval_at`   TIMESTAMP    NOT NULL COMMENT '발생시간',
     `status`        VARCHAR(100) NOT NULL COMMENT 'GPS 상태',
     `lat`           DECIMAL      NOT NULL COMMENT '위도 * 1000000 한값(소수점 6자리)',
@@ -122,8 +115,7 @@ CREATE TABLE cycle_info
 ) ENGINE = InnoDB COMMENT ='주기 정보';
 
 
-DROP TABLE IF EXISTS driving_history;
-CREATE TABLE driving_history
+CREATE TABLE IF NOT EXISTS driving_history
 (
     `driving_history_id`        BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '운행내역 PK',
     `vehicle_id`                BIGINT       NOT NULL COMMENT '차량 PK',

--- a/monicar-control-center/src/test/java/org/controlcenter/jpa/JpaTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/jpa/JpaTest.java
@@ -276,6 +276,7 @@ public class JpaTest {
 	void CycleInfoEntityTest() {
 		// given
 		CycleInfo cycleInfo = CycleInfo.builder()
+			.vehicleId(999L)
 			.status(GpsStatus.A)
 			.lat(BigDecimal.ONE)
 			.lon(BigDecimal.ONE)
@@ -300,6 +301,7 @@ public class JpaTest {
 			() -> assertThat(savedCycleInfo.getId()).isNotNull(),
 			() -> assertThat(savedCycleInfo.getCreatedAt()).isNotNull(),
 			() -> assertThat(savedCycleInfo.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedCycleInfo.getVehicleId()).isEqualTo(999L),
 			() -> assertThat(savedCycleInfo.getStatus()).isEqualTo(GpsStatus.A),
 			() -> assertThat(savedCycleInfo.getLat()).isEqualTo(BigDecimal.ONE),
 			() -> assertThat(savedCycleInfo.getLon()).isEqualTo(BigDecimal.ONE),
@@ -314,6 +316,7 @@ public class JpaTest {
 		// given
 		VehicleInformation vehicleInformation = VehicleInformation.builder()
 			.vehicleTypeId(999L)
+			.vehicleNumber("test vehicle name")
 			.mdn("test mdn")
 			.tid("test tid")
 			.mid(999)
@@ -338,6 +341,7 @@ public class JpaTest {
 			() -> assertThat(savedVehicleInformation.getId()).isNotNull(),
 			() -> assertThat(savedVehicleInformation.getCreatedAt()).isNotNull(),
 			() -> assertThat(savedVehicleInformation.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleInformation.getVehicleNumber()).isEqualTo("test vehicle name"),
 			() -> assertThat(savedVehicleInformation.getMdn()).isEqualTo("test mdn"),
 			() -> assertThat(savedVehicleInformation.getTid()).isEqualTo("test tid"),
 			() -> assertThat(savedVehicleInformation.getMid()).isEqualTo(999),

--- a/monicar-control-center/src/test/java/org/controlcenter/jpa/JpaTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/jpa/JpaTest.java
@@ -316,8 +316,8 @@ public class JpaTest {
 		// given
 		VehicleInformation vehicleInformation = VehicleInformation.builder()
 			.vehicleTypeId(999L)
-			.vehicleNumber("test vehicle name")
-			.mdn("test mdn")
+			.vehicleNumber("가나1234")
+			.mdn(999L)
 			.tid("test tid")
 			.mid(999)
 			.pv(999)
@@ -341,8 +341,8 @@ public class JpaTest {
 			() -> assertThat(savedVehicleInformation.getId()).isNotNull(),
 			() -> assertThat(savedVehicleInformation.getCreatedAt()).isNotNull(),
 			() -> assertThat(savedVehicleInformation.getUpdatedAt()).isNotNull(),
-			() -> assertThat(savedVehicleInformation.getVehicleNumber()).isEqualTo("test vehicle name"),
-			() -> assertThat(savedVehicleInformation.getMdn()).isEqualTo("test mdn"),
+			() -> assertThat(savedVehicleInformation.getVehicleNumber()).isEqualTo("가나1234"),
+			() -> assertThat(savedVehicleInformation.getMdn()).isEqualTo(999L),
 			() -> assertThat(savedVehicleInformation.getTid()).isEqualTo("test tid"),
 			() -> assertThat(savedVehicleInformation.getMid()).isEqualTo(999),
 			() -> assertThat(savedVehicleInformation.getPv()).isEqualTo(999),


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

차량 정보 조회 API 구현
- 해당 테이블이 없으면 생성되도록 init-schema.sql을 수정했습니다.
    - 테이블에 값을 추가한 후 애플리케이션을 다시 시작해도 데이터가 사라지지 않습니다. 
- 테이블에 필요한 필드를 추가했습니다.
- MyBatis 의존성 추가
- Querydsl 의존성 추가

## #️⃣ 연관된 이슈

#67 #53 

## 💡 리뷰어에게 하고 싶은 말

- 차량 정보 조회시 MyBatis 사용하여 개발하였습니다.
  - 조회 API 개발시 Querydsl 사용하기로 했으나, 기능 개발을 하면서 복잡성이 증가해 MyBatis로 변경하여 개발했습니다.
  - 각자 맡은 부분 개발 시 적절한 기능을 선택해서 개발하는 게 어떤지 의견을 여쭙고 싶습니다.   

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인