### PR TITLE
[Feature] collector모듈 내에 Producer, Consumer구현

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,5 +14,123 @@ services:
       TZ: ${DEV_MYSQL_TIME_ZONE}
     networks:
       - monicar
+  zookeeper:
+    image: 'bitnami/zookeeper:3.7.2'
+    container_name: zookeeper
+    ports:
+      - 2181:2181
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    volumes:
+      - ./.data/zookeeper/data:/bitnami/zookeeper/data
+      - ./.data/zookeeper/datalog:/bitnami/zookeeper/datalog
+      - ./.data/zookeeper/logs:/bitnami/zookeeper/logs
+    networks:
+      - monicar
+  kafka1:
+    image: 'bitnami/kafka:3.6.0'
+    container_name: kafka1
+    hostname: kafka1
+    ports:
+      - 19092
+      - "9092:9092"
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=CLIENT://:19092,EXTERNAL://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka1:19092,EXTERNAL://localhost:9092
+      - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+    depends_on:
+      - zookeeper
+    volumes:
+      - ./.data/kafka1:/bitnami/kafka/data
+    networks:
+      - monicar
+  kafka2:
+    image: 'bitnami/kafka:3.6.0'
+    container_name: kafka2
+    ports:
+      - 19092
+      - "9093:9093"
+    environment:
+      - KAFKA_BROKER_ID=2
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=CLIENT://:19092,EXTERNAL://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka2:19092,EXTERNAL://localhost:9093
+      - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+    depends_on:
+      - zookeeper
+    volumes:
+      - ./.data/kafka2:/bitnami/kafka/data
+    networks:
+      - monicar
+  kafka3:
+    image: 'bitnami/kafka:3.6.0'
+    container_name: kafka3
+    ports:
+      - 19092
+      - "9094:9094"
+    environment:
+      - KAFKA_BROKER_ID=3
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=CLIENT://:19092,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka3:19092,EXTERNAL://localhost:9094
+      - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+    depends_on:
+      - zookeeper
+    volumes:
+      - ./.data/kafka3:/bitnami/kafka/data
+    networks:
+      - monicar
+  kafka-ui:
+    image: 'provectuslabs/kafka-ui:v0.7.1'
+    container_name: kafka-ui
+    ports:
+      - "8081:8080"
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka1:19092,kafka2:19092,kafka3:19092
+    depends_on:
+      - zookeeper
+      - kafka1
+      - kafka2
+      - kafka3
+    networks:
+      - monicar
+  cmak:
+    image: 'hlebalbau/kafka-manager:3.0.0.5'
+    container_name: cmak
+    ports:
+      - "9000:9000"
+    environment:
+      - ZK_HOSTS=zookeeper:2181
+    depends_on:
+      - zookeeper
+      - kafka1
+      - kafka2
+      - kafka3
+    networks:
+      - monicar
+  redpanda-console:
+    image: 'docker.redpanda.com/redpandadata/console:v2.3.7'
+    container_name: redpanda-console
+    ports:
+      - "8989:8080"
+    environment:
+      - KAFKA_BROKERS=kafka1:19092,kafka2:19092,kafka3:19092
+    depends_on:
+      - zookeeper
+      - kafka1
+      - kafka2
+      - kafka3
+    networks:
+      - monicar
 networks:
   monicar:
+    driver: bridge

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -92,7 +92,7 @@ services:
     image: 'provectuslabs/kafka-ui:v0.7.1'
     container_name: kafka-ui
     ports:
-      - "8081:8080"
+      - "9091:8080"
     environment:
       - KAFKA_CLUSTERS_0_NAME=local
       - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka1:19092,kafka2:19092,kafka3:19092

--- a/monicar-collector/build.gradle
+++ b/monicar-collector/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "com.mysql:mysql-connector-j"
+    implementation "org.springframework.kafka:spring-kafka:3.3.0"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation project(':monicar-common')
 }

--- a/monicar-collector/src/main/java/org/collector/application/CycleInfoService.java
+++ b/monicar-collector/src/main/java/org/collector/application/CycleInfoService.java
@@ -3,7 +3,7 @@ package org.collector.application;
 import java.util.List;
 
 import org.collector.domain.CycleInfo;
-import org.collector.domain.Vehicle;
+import org.collector.domain.VehicleInformation;
 import org.collector.infrastructure.repository.CycleInfoRepository;
 import org.collector.infrastructure.repository.VehicleRepository;
 import org.collector.presentation.dto.CListRequest;
@@ -21,18 +21,18 @@ public class CycleInfoService {
 
 	@Transactional
 	public long cycleInfoSave(final CycleInfoRequest request) {
-		Vehicle vehicle = vehicleRepository.findByMdn(request.mdn())
+		VehicleInformation vehicleInformation = vehicleRepository.findByMdn(request.mdn())
 				.orElseThrow(IllegalArgumentException::new);
 
 		CycleInfoRequest.from(request);
 
-		vehicleRepository.save(vehicle);
+		vehicleRepository.save(vehicleInformation);
 
 		List<CycleInfo> cycleInfos = request.cList().stream()
-			.map(cListRequest -> CListRequest.from(cListRequest, vehicle))
+			.map(cListRequest -> CListRequest.from(cListRequest, vehicleInformation))
 			.toList();
 
 		cycleInfoRepository.saveAll(cycleInfos);
-		return vehicle.getMdn();
+		return vehicleInformation.getMdn();
 	}
 }

--- a/monicar-collector/src/main/java/org/collector/common/response/CommonResponse.java
+++ b/monicar-collector/src/main/java/org/collector/common/response/CommonResponse.java
@@ -11,8 +11,8 @@ public record CommonResponse<T>(
 	Object rstMsg,
 	String mdn
 ) {
-	public static <T> CommonResponse<T> ok(@Nullable final String mdn) {
-		return new CommonResponse<>(ResponseCode.SUCCESS.getCode(), ResponseCode.SUCCESS.getMessage(), mdn);
+	public static <T> CommonResponse<T> ok(final long mdn) {
+		return new CommonResponse<>(ResponseCode.SUCCESS.getCode(), ResponseCode.SUCCESS.getMessage(), Long.toString(mdn));
 	}
 
 	public static <T> CommonResponse<T> fail(final CustomException e, @Nullable final String mdn) {

--- a/monicar-collector/src/main/java/org/collector/config/KafkaConfig.java
+++ b/monicar-collector/src/main/java/org/collector/config/KafkaConfig.java
@@ -1,0 +1,50 @@
+package org.collector.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+public class KafkaConfig {
+
+	@Bean
+	@ConfigurationProperties("spring.kafka")
+	public KafkaProperties kafkaProperties() {
+		return new KafkaProperties();
+	}
+
+	@Bean
+	@Primary
+	public ConsumerFactory<String, Object> consumerFactory(KafkaProperties kafkaProperties) {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaProperties.getConsumer().getKeyDeserializer());
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaProperties.getConsumer().getValueDeserializer());
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+		props.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false");
+		return new DefaultKafkaConsumerFactory<>(props);
+	}
+
+	@Bean
+	@Primary
+	public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
+		ConsumerFactory<String, Object> consumerFactory
+	) {
+		ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(consumerFactory);
+		factory.setConcurrency(1);
+
+		return factory;
+	}
+}

--- a/monicar-collector/src/main/java/org/collector/config/KafkaConfig.java
+++ b/monicar-collector/src/main/java/org/collector/config/KafkaConfig.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -12,19 +13,22 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 @Configuration
 public class KafkaConfig {
 
 	@Bean
+	@Primary
 	@ConfigurationProperties("spring.kafka")
 	public KafkaProperties kafkaProperties() {
 		return new KafkaProperties();
 	}
 
 	@Bean
-	@Primary
 	public ConsumerFactory<String, Object> consumerFactory(KafkaProperties kafkaProperties) {
 		Map<String, Object> props = new HashMap<>();
 		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
@@ -37,7 +41,6 @@ public class KafkaConfig {
 	}
 
 	@Bean
-	@Primary
 	public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
 		ConsumerFactory<String, Object> consumerFactory
 	) {
@@ -46,5 +49,20 @@ public class KafkaConfig {
 		factory.setConcurrency(1);
 
 		return factory;
+	}
+
+	@Bean
+	public ProducerFactory<String, Object> producerFactory(KafkaProperties kafkaProperties) {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getKeySerializer());
+		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getValueSerializer());
+		props.put(ProducerConfig.ACKS_CONFIG, kafkaProperties.getProducer().getAcks());
+		return new DefaultKafkaProducerFactory<>(props);
+	}
+
+	@Bean
+	public KafkaTemplate<String, ?> kafkaTemplate(KafkaProperties kafkaProperties) {
+		return new KafkaTemplate<>(producerFactory(kafkaProperties));
 	}
 }

--- a/monicar-collector/src/main/java/org/collector/consumer/CycleInfoConsumer.java
+++ b/monicar-collector/src/main/java/org/collector/consumer/CycleInfoConsumer.java
@@ -1,0 +1,7 @@
+package org.collector.consumer;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class CycleInfoConsumer {
+}

--- a/monicar-collector/src/main/java/org/collector/consumer/CycleInfoConsumer.java
+++ b/monicar-collector/src/main/java/org/collector/consumer/CycleInfoConsumer.java
@@ -1,7 +1,18 @@
 package org.collector.consumer;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.collector.presentation.dto.CycleInfoRequest;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CycleInfoConsumer {
+
+	@KafkaListener(
+		topics = { "cycleInfo-json-topic" },
+		groupId = "consumer-group"
+	)
+	public void accept(ConsumerRecord<String, CycleInfoRequest> message) {
+		System.out.println("[Main Consumer] Message arrived! - " + message.value());
+	}
 }

--- a/monicar-collector/src/main/java/org/collector/domain/CycleInfo.java
+++ b/monicar-collector/src/main/java/org/collector/domain/CycleInfo.java
@@ -3,6 +3,7 @@ package org.collector.domain;
 import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 
 import org.collector.presentation.dto.GCD;
@@ -52,7 +53,10 @@ public class CycleInfo implements Serializable {
 	@JoinColumn(name = "vehicle_id")
 	private Vehicle vehicle;
 
-	public static BigDecimal convertToSixDecimalPlaces(Double value) {
-		return BigDecimal.valueOf(value / 1000000.0);
+	public static BigDecimal convertToSixDecimalPlaces(Integer value) {
+		if (value == null) {
+			return BigDecimal.ZERO;
+		}
+		return new BigDecimal(value).divide(new BigDecimal(1000000), 6, RoundingMode.HALF_UP);
 	}
 }

--- a/monicar-collector/src/main/java/org/collector/domain/CycleInfo.java
+++ b/monicar-collector/src/main/java/org/collector/domain/CycleInfo.java
@@ -51,7 +51,7 @@ public class CycleInfo implements Serializable {
 	private int bat;
 	@ManyToOne
 	@JoinColumn(name = "vehicle_id")
-	private Vehicle vehicle;
+	private VehicleInformation vehicleInformation;
 
 	public static BigDecimal convertToSixDecimalPlaces(Integer value) {
 		if (value == null) {

--- a/monicar-collector/src/main/java/org/collector/domain/VehicleInformation.java
+++ b/monicar-collector/src/main/java/org/collector/domain/VehicleInformation.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Vehicle implements Serializable {
+public class VehicleInformation implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	@Id

--- a/monicar-collector/src/main/java/org/collector/infrastructure/repository/VehicleRepository.java
+++ b/monicar-collector/src/main/java/org/collector/infrastructure/repository/VehicleRepository.java
@@ -1,0 +1,10 @@
+package org.collector.infrastructure.repository;
+
+import java.util.Optional;
+
+import org.collector.domain.Vehicle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
+	Optional<Vehicle> findByMdn(Long mdn);
+}

--- a/monicar-collector/src/main/java/org/collector/infrastructure/repository/VehicleRepository.java
+++ b/monicar-collector/src/main/java/org/collector/infrastructure/repository/VehicleRepository.java
@@ -2,9 +2,9 @@ package org.collector.infrastructure.repository;
 
 import java.util.Optional;
 
-import org.collector.domain.Vehicle;
+import org.collector.domain.VehicleInformation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
-	Optional<Vehicle> findByMdn(Long mdn);
+public interface VehicleRepository extends JpaRepository<VehicleInformation, Long> {
+	Optional<VehicleInformation> findByMdn(Long mdn);
 }

--- a/monicar-collector/src/main/java/org/collector/presentation/CycleInfoController.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/CycleInfoController.java
@@ -20,7 +20,7 @@ public class CycleInfoController {
 
 	@PostMapping
 	public CommonResponse<Void> cycleInfoSave(final @Valid @RequestBody CycleInfoRequest request) {
-		cycleInfoService.cycleInfoSave(request);
-		return CommonResponse.ok("111");
+		long mdn = cycleInfoService.cycleInfoSave(request);
+		return CommonResponse.ok(mdn);
 	}
 }

--- a/monicar-collector/src/main/java/org/collector/presentation/CycleInfoController.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/CycleInfoController.java
@@ -3,6 +3,7 @@ package org.collector.presentation;
 import org.collector.application.CycleInfoService;
 import org.collector.common.response.CommonResponse;
 import org.collector.presentation.dto.CycleInfoRequest;
+import org.collector.producer.CycleInfoProducer;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,10 +17,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CycleInfoController {
 
+	private final CycleInfoProducer cycleInfoProducer;
 	private final CycleInfoService cycleInfoService;
 
 	@PostMapping
 	public CommonResponse<Void> cycleInfoSave(final @Valid @RequestBody CycleInfoRequest request) {
+		cycleInfoProducer.sendMessage(request);
 		long mdn = cycleInfoService.cycleInfoSave(request);
 		return CommonResponse.ok(mdn);
 	}

--- a/monicar-collector/src/main/java/org/collector/presentation/dto/CListRequest.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/dto/CListRequest.java
@@ -2,6 +2,8 @@ package org.collector.presentation.dto;
 
 import java.time.LocalDateTime;
 
+import org.collector.domain.CycleInfo;
+import org.collector.domain.Vehicle;
 import org.hibernate.validator.constraints.Range;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -17,10 +19,12 @@ public record CListRequest(
 	GCD gcd,
 
 	@NotNull(message = "GPS 위도는 필수 입력값입니다.")
-	Double lat,
+	@Range(min = -90000000, max = 90000000, message = "위도는 -90백만 이상, 90백만 이하의 값이어야합니다.")
+	Integer lat,
 
 	@NotNull(message = "GPS 경도는 필수 입력값입니다.")
-	Double lon,
+	@Range(min = -180000000, max = 180000000, message = "경도는 -180백만 이상, 180백만 이하의 값이어야합니다.")
+	Integer lon,
 
 	@Range(min = 0, max = 365, message = "방향은 0 ~ 365 사이여야 합니다.")
 	@NotNull(message = "방향은 필수 입력값입니다.")
@@ -38,4 +42,17 @@ public record CListRequest(
 	@Range(min = 0, max = 9999, message = "배터리 전압은 0 ~ 9999 사이여야 합니다.")
 	Integer bat
 ) {
+	public static CycleInfo from(CListRequest request, Vehicle vehicle) {
+		return CycleInfo.builder()
+			.interval_at(request.interval_at())
+			.gcd(request.gcd())
+			.lat(CycleInfo.convertToSixDecimalPlaces(request.lat()))
+			.lon(CycleInfo.convertToSixDecimalPlaces(request.lon()))
+			.ang(request.ang())
+			.spd(request.spd())
+			.sum(request.sum())
+			.bat(request.bat())
+			.vehicle(vehicle)
+			.build();
+	}
 }

--- a/monicar-collector/src/main/java/org/collector/presentation/dto/CListRequest.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/dto/CListRequest.java
@@ -3,7 +3,7 @@ package org.collector.presentation.dto;
 import java.time.LocalDateTime;
 
 import org.collector.domain.CycleInfo;
-import org.collector.domain.Vehicle;
+import org.collector.domain.VehicleInformation;
 import org.hibernate.validator.constraints.Range;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -42,7 +42,7 @@ public record CListRequest(
 	@Range(min = 0, max = 9999, message = "배터리 전압은 0 ~ 9999 사이여야 합니다.")
 	Integer bat
 ) {
-	public static CycleInfo from(CListRequest request, Vehicle vehicle) {
+	public static CycleInfo from(CListRequest request, VehicleInformation vehicleInformation) {
 		return CycleInfo.builder()
 			.interval_at(request.interval_at())
 			.gcd(request.gcd())
@@ -52,7 +52,7 @@ public record CListRequest(
 			.spd(request.spd())
 			.sum(request.sum())
 			.bat(request.bat())
-			.vehicle(vehicle)
+			.vehicleInformation(vehicleInformation)
 			.build();
 	}
 }

--- a/monicar-collector/src/main/java/org/collector/presentation/dto/CycleInfoRequest.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/dto/CycleInfoRequest.java
@@ -3,7 +3,7 @@ package org.collector.presentation.dto;
 import java.util.List;
 
 import org.collector.common.annotation.MatchCycleSize;
-import org.collector.domain.Vehicle;
+import org.collector.domain.VehicleInformation;
 import org.hibernate.validator.constraints.Range;
 
 import jakarta.validation.Valid;
@@ -34,8 +34,8 @@ public record CycleInfoRequest(
 	@Valid
 	List<CListRequest> cList
 ) {
-	public static Vehicle from(CycleInfoRequest request) {
-		return Vehicle.builder()
+	public static VehicleInformation from(CycleInfoRequest request) {
+		return VehicleInformation.builder()
 			.mdn(request.mdn())
 			.tid(request.tid())
 			.mid(request.mid())

--- a/monicar-collector/src/main/java/org/collector/presentation/dto/CycleInfoRequest.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/dto/CycleInfoRequest.java
@@ -3,6 +3,7 @@ package org.collector.presentation.dto;
 import java.util.List;
 
 import org.collector.common.annotation.MatchCycleSize;
+import org.collector.domain.Vehicle;
 import org.hibernate.validator.constraints.Range;
 
 import jakarta.validation.Valid;
@@ -33,4 +34,13 @@ public record CycleInfoRequest(
 	@Valid
 	List<CListRequest> cList
 ) {
+	public static Vehicle from(CycleInfoRequest request) {
+		return Vehicle.builder()
+			.mdn(request.mdn())
+			.tid(request.tid())
+			.mid(request.mid())
+			.pv(request.pv())
+			.did(request.did())
+			.build();
+	}
 }

--- a/monicar-collector/src/main/java/org/collector/producer/CycleInfoProducer.java
+++ b/monicar-collector/src/main/java/org/collector/producer/CycleInfoProducer.java
@@ -1,0 +1,20 @@
+package org.collector.producer;
+
+import org.collector.presentation.dto.CycleInfoRequest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class CycleInfoProducer {
+	private final KafkaTemplate<String, CycleInfoRequest> kafkaTemplate;
+
+	public void sendMessage(CycleInfoRequest message) {
+		log.info("send message: {}", message);
+		kafkaTemplate.send("cycleInfo-json-topic", String.valueOf(message.mdn()), message);
+	}
+}

--- a/monicar-collector/src/main/resources/application.yml
+++ b/monicar-collector/src/main/resources/application.yml
@@ -21,6 +21,20 @@ spring:
       hibernate.format_sql: true
       dialect: org.hibernate.dialect.MySQL8InnoDBDialect
 
+  kafka:
+    json:
+      bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
+      consumer:
+        key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+        auto-offset-reset: latest
+      listener:
+        concurrency: 1
+      producer:
+        key-serializer: org.apache.kafka.common.serialization.StringSerializer
+        value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+        acks: 1
+
 
 logging:
   level:

--- a/monicar-collector/src/main/resources/application.yml
+++ b/monicar-collector/src/main/resources/application.yml
@@ -5,11 +5,15 @@ spring:
   application:
     name: monicar-collector
 
+#  datasource:
+#    driver-class-name: com.mysql.cj.jdbc.Driver
+#    url: jdbc:mysql://localhost:3306/monicar?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+#    username: root
+#    password:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/monicar?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: root
-    password:
+    url: jdbc:mysql://localhost:3306/monicar_db
+    username: local_user
+    password: local_password
 
 
   jpa:
@@ -22,18 +26,18 @@ spring:
       dialect: org.hibernate.dialect.MySQL8InnoDBDialect
 
   kafka:
-    json:
-      bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
-      consumer:
-        key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-        value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-        auto-offset-reset: latest
-      listener:
-        concurrency: 1
-      producer:
-        key-serializer: org.apache.kafka.common.serialization.StringSerializer
-        value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-        acks: 1
+    bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      auto-offset-reset: latest
+    listener:
+      concurrency: 1
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: 1
+
 
 
 logging:

--- a/monicar-control-center/build.gradle
+++ b/monicar-control-center/build.gradle
@@ -3,6 +3,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
 
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    testImplementation("org.testcontainers:testcontainers")
+    testImplementation("org.testcontainers:mysql")
 }
 
 tasks.bootJar {

--- a/monicar-control-center/build.gradle
+++ b/monicar-control-center/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
+    implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/monicar-control-center/src/main/java/org/controlcenter/ControlCenterApplication.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/ControlCenterApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class ControlCenterApplication {
-    public static void main(String[] args) {
-        SpringApplication.run(ControlCenterApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(ControlCenterApplication.class, args);
+	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/Alarm.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/Alarm.java
@@ -1,0 +1,18 @@
+package org.controlcenter.alarm.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Alarm {
+	private Long id;
+	private Long managerId;
+	private String description;
+	private AlarmStatus status;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/AlarmStatus.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/AlarmStatus.java
@@ -1,0 +1,6 @@
+package org.controlcenter.alarm.domain;
+
+public enum AlarmStatus {
+	CHECKED,
+	UNCHECKED
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/AlarmJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/AlarmJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.alarm.infrastructure.jpa;
+
+import org.controlcenter.alarm.infrastructure.jpa.entity.AlarmEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmJpaRepository extends JpaRepository<AlarmEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/entity/AlarmEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/entity/AlarmEntity.java
@@ -1,0 +1,69 @@
+package org.controlcenter.alarm.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.alarm.domain.Alarm;
+import org.controlcenter.alarm.domain.AlarmStatus;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "alarm")
+public class AlarmEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "alarm_id")
+	private Long id;
+
+	private Long managerId;
+
+	private String description;
+
+	@Enumerated(value = EnumType.STRING)
+	private AlarmStatus status;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static AlarmEntity from(Alarm alarm) {
+		AlarmEntity alarmEntity = new AlarmEntity();
+		alarmEntity.id = alarm.getId();
+		alarmEntity.managerId = alarm.getManagerId();
+		alarmEntity.description = alarm.getDescription();
+		alarmEntity.status = alarm.getStatus();
+		alarmEntity.createdAt = alarm.getCreatedAt();
+		alarmEntity.updatedAt = alarm.getUpdatedAt();
+		alarmEntity.deletedAt = alarm.getDeletedAt();
+		return alarmEntity;
+	}
+
+	public Alarm toDomain() {
+		return Alarm.builder()
+			.id(id)
+			.managerId(managerId)
+			.description(description)
+			.status(status)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/common/exception/BusinessException.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/exception/BusinessException.java
@@ -1,8 +1,8 @@
 package org.controlcenter.common.exception;
 
-import lombok.Getter;
-
 import org.controlcenter.common.response.code.ErrorCode;
+
+import lombok.Getter;
 
 @Getter
 public class BusinessException extends RuntimeException {

--- a/monicar-control-center/src/main/java/org/controlcenter/common/exception/GlobalExceptionHandler.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/exception/GlobalExceptionHandler.java
@@ -43,8 +43,8 @@ public class GlobalExceptionHandler {
 	}
 
 	/**
-	 * enum 타입이 일치하지 않을 때 발생하는 예외 처리
-	 * RequestParam 으로 전달된 enum 타입의 값이 맞지 않을 때 주로 발생
+	 * 타입이 일치하지 않을 때 발생하는 예외 처리
+	 * RequestParam 으로 전달된 값의 타입이 맞지 않을 때 주로 발생
 	 */
 	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
 	protected BaseResponse<String> handleMethodArgumentTypeMismatchException(
@@ -60,7 +60,7 @@ public class GlobalExceptionHandler {
 			.map(fieldError -> String.format("%s : %s", fieldError.getField(), fieldError.getDefaultMessage()))
 			.toList();
 
-		log.error("Business Exception 발생: {}", errors);
+		log.error("Business Exception 발생: {}", errors, e);
 
 		return BaseResponse.fail(errors);
 	}

--- a/monicar-control-center/src/main/java/org/controlcenter/common/response/BaseResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/response/BaseResponse.java
@@ -32,6 +32,9 @@ public class BaseResponse<T> {
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private final Integer errorCode;
 
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final Long timestamp;
+
 	public static <T> BaseResponse<T> success(SuccessCode code, T data) {
 		return BaseResponse.<T>builder()
 			.isSuccess(true)
@@ -64,6 +67,7 @@ public class BaseResponse<T> {
 			.isSuccess(false)
 			.errorMessage(List.of(code.getMessage()))
 			.errorCode(code.getCode())
+			.timestamp(System.currentTimeMillis())
 			.build();
 	}
 
@@ -72,6 +76,7 @@ public class BaseResponse<T> {
 			.isSuccess(false)
 			.errorMessage(errorMessages)
 			.errorCode(1000)
+			.timestamp(System.currentTimeMillis())
 			.build();
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/common/response/BaseResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/response/BaseResponse.java
@@ -33,15 +33,26 @@ public class BaseResponse<T> {
 	private final Integer errorCode;
 
 	public static <T> BaseResponse<T> success(SuccessCode code, T data) {
-		return new BaseResponse<>(true, code.getMessage(), null, data, null);
+		return BaseResponse.<T>builder()
+			.isSuccess(true)
+			.message(code.getMessage())
+			.result(data)
+			.build();
 	}
 
 	public static <T> BaseResponse<T> success(T data) {
-		return new BaseResponse<>(true, SuccessCode.OK.getMessage(), null, data, null);
+		return BaseResponse.<T>builder()
+			.isSuccess(true)
+			.message(SuccessCode.OK.getMessage())
+			.result(data)
+			.build();
 	}
 
 	public static <T> BaseResponse<T> success(SuccessCode code) {
-		return new BaseResponse<>(true, code.getMessage(), null, null, null);
+		return BaseResponse.<T>builder()
+			.isSuccess(true)
+			.message(code.getMessage())
+			.build();
 	}
 
 	public static BaseResponse<Void> success() {
@@ -49,10 +60,18 @@ public class BaseResponse<T> {
 	}
 
 	public static <T> BaseResponse<T> fail(ErrorCode code) {
-		return new BaseResponse<>(false, null, List.of(code.getMessage()), null, code.getCode());
+		return BaseResponse.<T>builder()
+			.isSuccess(false)
+			.errorMessage(List.of(code.getMessage()))
+			.errorCode(code.getCode())
+			.build();
 	}
 
 	public static <T> BaseResponse<T> fail(List<String> errorMessages) {
-		return new BaseResponse<>(false, null, errorMessages, null, 1000);
+		return BaseResponse.<T>builder()
+			.isSuccess(false)
+			.errorMessage(errorMessages)
+			.errorCode(1000)
+			.build();
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ErrorCode.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
 	INVALID_TYPE_VALUE(1005, "잘못된 유형 값을 입력하였습니다."),
 	HANDLE_ACCESS_DENIED(1006, "액세스가 거부되었습니다."),
 	FORBIDDEN_ACCESS(1007, "비정상적 접근입니다."),
-	EMPTY_PATH_VARIABLE(1008, "필수 경로 변수가 누락되었습니다. 요청 경로에 올바른 값을 입력해 주세요.");
+	EMPTY_PATH_VARIABLE(1008, "필수 경로 변수가 누락되었습니다. 요청 경로에 올바른 값을 입력해 주세요."),
+	ENTITY_ALREADY_EXIST(1009, "이미 존재하는 엔티티 입니다.");
 
 	private final int code;
 	private final String message;

--- a/monicar-control-center/src/main/java/org/controlcenter/company/application/CompanyService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/application/CompanyService.java
@@ -1,0 +1,29 @@
+package org.controlcenter.company.application;
+
+import java.util.Optional;
+
+import org.controlcenter.company.application.port.CompanyRepository;
+import org.controlcenter.company.domain.Company;
+import org.controlcenter.company.domain.CompanyCreate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class CompanyService {
+	private final CompanyRepository companyRepository;
+
+	@Transactional
+	public Company register(CompanyCreate command) {
+		Company company = Company.create(command);
+
+		return companyRepository.save(company);
+	}
+
+	private Optional<Company> findByCompanyName(String companyName) {
+		return companyRepository.findByCompanyName(companyName);
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/application/CompanyService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/application/CompanyService.java
@@ -1,7 +1,7 @@
 package org.controlcenter.company.application;
 
-import java.util.Optional;
-
+import org.controlcenter.common.exception.BusinessException;
+import org.controlcenter.common.response.code.ErrorCode;
 import org.controlcenter.company.application.port.CompanyRepository;
 import org.controlcenter.company.domain.Company;
 import org.controlcenter.company.domain.CompanyCreate;
@@ -18,12 +18,16 @@ public class CompanyService {
 
 	@Transactional
 	public Company register(CompanyCreate command) {
-		Company company = Company.create(command);
+		validateAlreadyExistCompanyName(command.getCompanyName());
 
-		return companyRepository.save(company);
+		return companyRepository.save(Company.create(command));
 	}
 
-	private Optional<Company> findByCompanyName(String companyName) {
-		return companyRepository.findByCompanyName(companyName);
+	private void validateAlreadyExistCompanyName(String companyName) {
+		companyRepository.findByCompanyName(companyName)
+			.ifPresent(existCompany -> {
+				throw new BusinessException(ErrorCode.ENTITY_ALREADY_EXIST);
+			});
 	}
+
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/company/application/port/CompanyRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/application/port/CompanyRepository.java
@@ -1,0 +1,11 @@
+package org.controlcenter.company.application.port;
+
+import java.util.Optional;
+
+import org.controlcenter.company.domain.Company;
+
+public interface CompanyRepository {
+	Company save(Company company);
+
+	Optional<Company> findByCompanyName(String companyName);
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/Company.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/Company.java
@@ -1,0 +1,17 @@
+package org.controlcenter.company.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Company {
+	private Long id;
+	private String companyName;
+	private String businessRegistrationNumber;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/Company.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/Company.java
@@ -1,9 +1,9 @@
 package org.controlcenter.company.domain;
 
-import java.time.LocalDateTime;
-
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
@@ -14,4 +14,11 @@ public class Company {
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 	private LocalDateTime deletedAt;
+
+    public static Company create(CompanyCreate companyCreate) {
+        return Company.builder()
+                .companyName(companyCreate.getCompanyName())
+                .businessRegistrationNumber(companyCreate.getBusinessRegistrationNumber())
+                .build();
+    }
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/CompanyCreate.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/CompanyCreate.java
@@ -1,0 +1,42 @@
+package org.controlcenter.company.domain;
+
+import org.controlcenter.common.exception.BusinessException;
+import org.controlcenter.common.response.code.ErrorCode;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CompanyCreate {
+	public static final int MAX_COMPANY_SIZE = 10;
+
+	private final String companyName;
+	private final String businessRegistrationNumber;
+
+	private CompanyCreate(
+		String companyName,
+		String businessRegistrationNumber
+	) {
+		this.companyName = companyName;
+		this.businessRegistrationNumber = businessRegistrationNumber;
+	}
+
+	public static CompanyCreate of(
+		String companyName,
+		String businessRegistrationNumber
+	) {
+		validateCompanyNameSize(companyName);
+
+		return new CompanyCreate(
+			companyName,
+			businessRegistrationNumber
+		);
+	}
+
+	private static void validateCompanyNameSize(String companyName) {
+		if (companyName.length() > MAX_COMPANY_SIZE) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/Department.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/Department.java
@@ -1,0 +1,17 @@
+package org.controlcenter.company.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Department {
+	private Long id;
+	private Long companyId;
+	private String departmentName;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/Manager.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/Manager.java
@@ -1,0 +1,22 @@
+package org.controlcenter.company.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Manager {
+	private Long id;
+	private Long departmentId;
+	private String email;
+	private String loginId;
+	private String password;
+	private String nickname;
+	private Role role;
+	private LocalDateTime lastLoginedAt;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/Role.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/Role.java
@@ -1,0 +1,6 @@
+package org.controlcenter.company.domain;
+
+public enum Role {
+	ROLE_USER,
+	ROLE_ADMIN
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.company.infrastructure.jpa;
+
+import org.controlcenter.company.infrastructure.jpa.entity.CompanyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyJpaRepository extends JpaRepository<CompanyEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyJpaRepository.java
@@ -1,7 +1,11 @@
 package org.controlcenter.company.infrastructure.jpa;
 
+import org.controlcenter.company.domain.Company;
 import org.controlcenter.company.infrastructure.jpa.entity.CompanyEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CompanyJpaRepository extends JpaRepository<CompanyEntity, Long> {
+    Optional<Company> findByCompanyName(String companyName);
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyRepositoryAdapter.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/CompanyRepositoryAdapter.java
@@ -1,0 +1,27 @@
+package org.controlcenter.company.infrastructure.jpa;
+
+import java.util.Optional;
+
+import org.controlcenter.company.application.port.CompanyRepository;
+import org.controlcenter.company.domain.Company;
+import org.controlcenter.company.infrastructure.jpa.entity.CompanyEntity;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class CompanyRepositoryAdapter implements CompanyRepository {
+	private final CompanyJpaRepository companyJpaRepository;
+
+	@Override
+	public Company save(Company company) {
+		return companyJpaRepository.save(CompanyEntity.from(company))
+			.toDomain();
+	}
+
+	@Override
+	public Optional<Company> findByCompanyName(String companyName) {
+		return companyJpaRepository.findByCompanyName(companyName);
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/DepartmentJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/DepartmentJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.company.infrastructure.jpa;
+
+import org.controlcenter.company.infrastructure.jpa.entity.DepartmentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DepartmentJpaRepository extends JpaRepository<DepartmentEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/ManagerJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/ManagerJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.company.infrastructure.jpa;
+
+import org.controlcenter.company.infrastructure.jpa.entity.ManagerEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ManagerJpaRepository extends JpaRepository<ManagerEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/CompanyEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/CompanyEntity.java
@@ -1,0 +1,61 @@
+package org.controlcenter.company.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.company.domain.Company;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "company")
+public class CompanyEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "company_id")
+	private Long id;
+
+	private String companyName;
+
+	private String businessRegistrationNumber;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static CompanyEntity from(Company company) {
+		CompanyEntity companyEntity = new CompanyEntity();
+		companyEntity.id = company.getId();
+		companyEntity.companyName = company.getCompanyName();
+		companyEntity.businessRegistrationNumber = company.getBusinessRegistrationNumber();
+		companyEntity.createdAt = company.getCreatedAt();
+		companyEntity.updatedAt = company.getUpdatedAt();
+		companyEntity.deletedAt = company.getDeletedAt();
+		return companyEntity;
+	}
+
+	public Company toDomain() {
+		return Company.builder()
+			.id(id)
+			.companyName(companyName)
+			.businessRegistrationNumber(businessRegistrationNumber)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/DepartmentEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/DepartmentEntity.java
@@ -1,0 +1,61 @@
+package org.controlcenter.company.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.company.domain.Department;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "department")
+public class DepartmentEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "department_id")
+	private Long id;
+
+	private Long companyId;
+
+	private String departmentName;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static DepartmentEntity from(Department department) {
+		DepartmentEntity departmentEntity = new DepartmentEntity();
+		departmentEntity.id = department.getId();
+		departmentEntity.companyId = department.getCompanyId();
+		departmentEntity.departmentName = department.getDepartmentName();
+		departmentEntity.createdAt = department.getCreatedAt();
+		departmentEntity.updatedAt = department.getUpdatedAt();
+		departmentEntity.deletedAt = department.getDeletedAt();
+		return departmentEntity;
+	}
+
+	public Department toDomain() {
+		return Department.builder()
+			.id(id)
+			.companyId(companyId)
+			.departmentName(departmentName)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/ManagerEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/infrastructure/jpa/entity/ManagerEntity.java
@@ -1,0 +1,85 @@
+package org.controlcenter.company.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.company.domain.Manager;
+import org.controlcenter.company.domain.Role;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "manager")
+public class ManagerEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "manager_id")
+	private Long id;
+
+	private Long departmentId;
+
+	private String email;
+
+	private String loginId;
+
+	private String password;
+
+	private String nickname;
+
+	@Enumerated(value = EnumType.STRING)
+	private Role role;
+
+	private LocalDateTime lastLoginedAt;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static ManagerEntity from(Manager manager) {
+		ManagerEntity managerEntity = new ManagerEntity();
+		managerEntity.id = manager.getId();
+		managerEntity.departmentId = manager.getDepartmentId();
+		managerEntity.email = manager.getEmail();
+		managerEntity.loginId = manager.getLoginId();
+		managerEntity.password = manager.getPassword();
+		managerEntity.nickname = manager.getNickname();
+		managerEntity.role = manager.getRole();
+		managerEntity.lastLoginedAt = manager.getLastLoginedAt();
+		managerEntity.createdAt = manager.getCreatedAt();
+		managerEntity.updatedAt = manager.getUpdatedAt();
+		managerEntity.deletedAt = manager.getDeletedAt();
+		return managerEntity;
+	}
+
+	public Manager toDomain() {
+		return Manager.builder()
+			.id(id)
+			.departmentId(departmentId)
+			.email(email)
+			.loginId(loginId)
+			.password(password)
+			.nickname(nickname)
+			.role(role)
+			.lastLoginedAt(lastLoginedAt)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/presentation/CompanyController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/presentation/CompanyController.java
@@ -1,0 +1,34 @@
+package org.controlcenter.company.presentation;
+
+import org.controlcenter.common.response.BaseResponse;
+import org.controlcenter.company.application.CompanyService;
+import org.controlcenter.company.presentation.dto.CompanyCreateRequest;
+import org.controlcenter.company.presentation.dto.SimpleCompanyResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/companies")
+public class CompanyController {
+	private final CompanyService companyService;
+
+	/**
+	 * 업체(회사) 등록 api
+	 *
+	 * @param companyCreateRequest 업체(회사) 등록 요청 데이터
+	 * @return 등록된 업체 데이터를 반환
+	 */
+	@PostMapping
+	public BaseResponse<SimpleCompanyResponse> register(
+		@Valid @RequestBody CompanyCreateRequest companyCreateRequest
+	) {
+		var company = companyService.register(companyCreateRequest.toDomain());
+		return BaseResponse.success(SimpleCompanyResponse.from(company));
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/presentation/dto/CompanyCreateRequest.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/presentation/dto/CompanyCreateRequest.java
@@ -1,0 +1,22 @@
+package org.controlcenter.company.presentation.dto;
+
+import org.controlcenter.company.domain.CompanyCreate;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record CompanyCreateRequest(
+	@NotBlank(message = "회사 이름은 null 또는 비어 있을 수 없습니다.")
+	String companyName,
+
+	@NotBlank(message = "회사 등록 번호는 null 또는 비어 있을 수 없습니다.")
+	String businessRegistrationNumber
+) {
+	public CompanyCreate toDomain() {
+		return CompanyCreate.of(
+			companyName,
+			businessRegistrationNumber
+		);
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/presentation/dto/SimpleCompanyResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/presentation/dto/SimpleCompanyResponse.java
@@ -1,0 +1,28 @@
+package org.controlcenter.company.presentation.dto;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.company.domain.Company;
+
+import lombok.Builder;
+
+@Builder
+public record SimpleCompanyResponse(
+	Long id,
+	String companyName,
+	String businessRegistrationNumber,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt,
+	LocalDateTime deletedAt
+) {
+	public static SimpleCompanyResponse from(Company company) {
+		return SimpleCompanyResponse.builder()
+			.id(company.getId())
+			.companyName(company.getCompanyName())
+			.businessRegistrationNumber(company.getBusinessRegistrationNumber())
+			.createdAt(company.getCreatedAt())
+			.updatedAt(company.getUpdatedAt())
+			.deletedAt(company.getDeletedAt())
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/config/JpaConfig.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package org.controlcenter.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/geoinfo/domain/CycleInfo.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/geoinfo/domain/CycleInfo.java
@@ -1,0 +1,26 @@
+package org.controlcenter.geoinfo.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CycleInfo {
+	private long id;
+	private GpsStatus status;
+	private BigDecimal lat;
+	private BigDecimal lon;
+	private Integer ang;
+	private Integer spd;
+	private LocalDateTime intervalAt;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+
+	public static BigDecimal convertToSixDecimalPlaces(Double value) {
+		return BigDecimal.valueOf(value / 1000000.0);
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/geoinfo/domain/GpsStatus.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/geoinfo/domain/GpsStatus.java
@@ -1,0 +1,13 @@
+package org.controlcenter.geoinfo.domain;
+
+public enum GpsStatus {
+	A("정상"),
+	V("비정상"),
+	O("미장착");
+
+	private String description;
+
+	GpsStatus(String description) {
+		this.description = description;
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/geoinfo/infrastructure/jpa/CycleInfoJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/geoinfo/infrastructure/jpa/CycleInfoJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.geoinfo.infrastructure.jpa;
+
+import org.controlcenter.geoinfo.infrastructure.jpa.entity.CycleInfoEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CycleInfoJpaRepository extends JpaRepository<CycleInfoEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/geoinfo/infrastructure/jpa/entity/CycleInfoEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/geoinfo/infrastructure/jpa/entity/CycleInfoEntity.java
@@ -1,0 +1,85 @@
+package org.controlcenter.geoinfo.infrastructure.jpa.entity;
+
+import java.io.Serial;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.controlcenter.geoinfo.domain.CycleInfo;
+import org.controlcenter.geoinfo.domain.GpsStatus;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "cycle_info")
+public class CycleInfoEntity {
+	@Serial
+	private static final long serialVersionUID = 1L;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "cycle_info_id")
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	private GpsStatus status;
+
+	private BigDecimal lat;
+
+	private BigDecimal lon;
+
+	private Integer ang;
+
+	private Integer spd;
+
+	private LocalDateTime intervalAt;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static CycleInfoEntity from(CycleInfo cycleInfo) {
+		CycleInfoEntity cycleInfoEntity = new CycleInfoEntity();
+		cycleInfoEntity.id = cycleInfo.getId();
+		cycleInfoEntity.status = cycleInfo.getStatus();
+		cycleInfoEntity.lat = cycleInfo.getLat();
+		cycleInfoEntity.lon = cycleInfo.getLon();
+		cycleInfoEntity.ang = cycleInfo.getAng();
+		cycleInfoEntity.spd = cycleInfo.getSpd();
+		cycleInfoEntity.intervalAt = cycleInfo.getIntervalAt();
+		cycleInfoEntity.createdAt = cycleInfo.getCreatedAt();
+		cycleInfoEntity.updatedAt = cycleInfo.getUpdatedAt();
+		cycleInfoEntity.deletedAt = cycleInfo.getDeletedAt();
+		return cycleInfoEntity;
+	}
+
+	public CycleInfo toDomain() {
+		return CycleInfo.builder()
+			.id(id)
+			.status(status)
+			.lat(lat)
+			.lon(lon)
+			.ang(ang)
+			.spd(spd)
+			.intervalAt(intervalAt)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/history/domain/DrivingHistory.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/history/domain/DrivingHistory.java
@@ -1,0 +1,27 @@
+package org.controlcenter.history.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class DrivingHistory {
+	private Long id;
+	private Long vehicleId;
+	private Long departmentId;
+	private String driverEmail;
+	private Double initialOdometer;
+	private Double finalOdometer;
+	private Double drivingDistance;
+	private Double businessCommuteDistance;
+	private Double businessUsageDistance;
+	private Boolean isBusinessUse;
+	private LocalDateTime usedAt;
+	private LocalDateTime onTime;
+	private LocalDateTime offTime;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/history/infrastructure/jpa/DrivingHistoryJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/history/infrastructure/jpa/DrivingHistoryJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.history.infrastructure.jpa;
+
+import org.controlcenter.history.infrastructure.jpa.entity.DrivingHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DrivingHistoryJpaRepository extends JpaRepository<DrivingHistoryEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/history/infrastructure/jpa/entity/DrivingHistoryEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/history/infrastructure/jpa/entity/DrivingHistoryEntity.java
@@ -1,0 +1,101 @@
+package org.controlcenter.history.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.history.domain.DrivingHistory;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "driving_history")
+public class DrivingHistoryEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "driving_history_id")
+	private Long id;
+
+	private Long vehicleId;
+
+	private Long departmentId;
+
+	private String driverEmail;
+
+	private Double initialOdometer;
+
+	private Double finalOdometer;
+
+	private Double drivingDistance;
+
+	private Double businessCommuteDistance;
+
+	private Double businessUsageDistance;
+
+	private Boolean isBusinessUse;
+
+	private LocalDateTime usedAt;
+
+	private LocalDateTime onTime;
+
+	private LocalDateTime offTime;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static DrivingHistoryEntity from(DrivingHistory drivingHistory) {
+		DrivingHistoryEntity drivingHistoryEntity = new DrivingHistoryEntity();
+		drivingHistoryEntity.id = drivingHistory.getId();
+		drivingHistoryEntity.vehicleId = drivingHistory.getVehicleId();
+		drivingHistoryEntity.departmentId = drivingHistory.getDepartmentId();
+		drivingHistoryEntity.driverEmail = drivingHistory.getDriverEmail();
+		drivingHistoryEntity.initialOdometer = drivingHistory.getInitialOdometer();
+		drivingHistoryEntity.finalOdometer = drivingHistory.getFinalOdometer();
+		drivingHistoryEntity.drivingDistance = drivingHistory.getDrivingDistance();
+		drivingHistoryEntity.businessCommuteDistance = drivingHistory.getBusinessCommuteDistance();
+		drivingHistoryEntity.businessUsageDistance = drivingHistory.getBusinessUsageDistance();
+		drivingHistoryEntity.isBusinessUse = drivingHistory.getIsBusinessUse();
+		drivingHistoryEntity.usedAt = drivingHistory.getUsedAt();
+		drivingHistoryEntity.onTime = drivingHistory.getOnTime();
+		drivingHistoryEntity.offTime = drivingHistory.getOffTime();
+		drivingHistoryEntity.createdAt = drivingHistory.getCreatedAt();
+		drivingHistoryEntity.updatedAt = drivingHistory.getUpdatedAt();
+		drivingHistoryEntity.deletedAt = drivingHistory.getDeletedAt();
+		return drivingHistoryEntity;
+	}
+
+	public DrivingHistory toDomain() {
+		return DrivingHistory.builder()
+			.id(id)
+			.vehicleId(vehicleId)
+			.departmentId(departmentId)
+			.driverEmail(driverEmail)
+			.initialOdometer(initialOdometer)
+			.finalOdometer(finalOdometer)
+			.drivingDistance(drivingDistance)
+			.businessCommuteDistance(businessCommuteDistance)
+			.businessUsageDistance(businessUsageDistance)
+			.isBusinessUse(isBusinessUse)
+			.usedAt(usedAt)
+			.onTime(onTime)
+			.offTime(offTime)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/notice/domain/Notice.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/notice/domain/Notice.java
@@ -1,0 +1,18 @@
+package org.controlcenter.notice.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Notice {
+	private Long id;
+	private String title;
+	private String content;
+	private String imageUrl;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/notice/infrastructure/jpa/NoticeJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/notice/infrastructure/jpa/NoticeJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.notice.infrastructure.jpa;
+
+import org.controlcenter.notice.infrastructure.jpa.entity.NoticeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeJpaRepository extends JpaRepository<NoticeEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/notice/infrastructure/jpa/entity/NoticeEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/notice/infrastructure/jpa/entity/NoticeEntity.java
@@ -1,0 +1,65 @@
+package org.controlcenter.notice.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.notice.domain.Notice;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "notice")
+public class NoticeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notice_id")
+	private Long id;
+
+	private String title;
+
+	private String content;
+
+	private String imageUrl;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static NoticeEntity from(Notice notice) {
+		NoticeEntity noticeEntity = new NoticeEntity();
+		noticeEntity.id = notice.getId();
+		noticeEntity.title = notice.getTitle();
+		noticeEntity.content = notice.getContent();
+		noticeEntity.imageUrl = notice.getImageUrl();
+		noticeEntity.createdAt = notice.getCreatedAt();
+		noticeEntity.updatedAt = notice.getUpdatedAt();
+		noticeEntity.deletedAt = notice.getDeletedAt();
+		return noticeEntity;
+	}
+
+	public Notice toDomain() {
+		return Notice.builder()
+			.id(id)
+			.title(title)
+			.content(content)
+			.imageUrl(imageUrl)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEvent.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEvent.java
@@ -1,0 +1,18 @@
+package org.controlcenter.vehicle.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class VehicleEvent {
+	private Long id;
+	private Long vehicleId;
+	private VehicleEventType type;
+	private LocalDateTime eventAt;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEventType.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEventType.java
@@ -1,0 +1,6 @@
+package org.controlcenter.vehicle.domain;
+
+public enum VehicleEventType {
+	ON,
+	OFF
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleInformation.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleInformation.java
@@ -1,0 +1,22 @@
+package org.controlcenter.vehicle.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class VehicleInformation {
+	private Long id;
+	private Long vehicleTypeId;
+	private String mdn;
+	private String tid;
+	private Integer mid;
+	private Integer pv;
+	private Integer did;
+	private Integer sum;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleInformation.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleInformation.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 public class VehicleInformation {
 	private Long id;
 	private Long vehicleTypeId;
-	private String mdn;
+	private Long mdn;
 	private String tid;
 	private Integer mid;
 	private Integer pv;

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleType.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleType.java
@@ -1,0 +1,16 @@
+package org.controlcenter.vehicle.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class VehicleType {
+	private Long id;
+	private String vehicleTypesName;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleEventJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleEventJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.vehicle.infrastructure.jpa;
+
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleEventEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VehicleEventJpaRepository extends JpaRepository<VehicleEventEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleInformationJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleInformationJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.vehicle.infrastructure.jpa;
+
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleInformationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VehicleInformationJpaRepository extends JpaRepository<VehicleInformationEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleTypesJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleTypesJpaRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.vehicle.infrastructure.jpa;
+
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleTypeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VehicleTypesJpaRepository extends JpaRepository<VehicleTypeEntity, Long> {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleEventEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleEventEntity.java
@@ -1,0 +1,69 @@
+package org.controlcenter.vehicle.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.vehicle.domain.VehicleEvent;
+import org.controlcenter.vehicle.domain.VehicleEventType;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "vehicle_event")
+public class VehicleEventEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "vehicle_event_id")
+	private Long id;
+
+	private Long vehicleId;
+
+	@Enumerated(value = EnumType.STRING)
+	private VehicleEventType type;
+
+	private LocalDateTime eventAt;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static VehicleEventEntity from(VehicleEvent vehicleEvent) {
+		VehicleEventEntity vehicleEventEntity = new VehicleEventEntity();
+		vehicleEventEntity.id = vehicleEvent.getId();
+		vehicleEventEntity.vehicleId = vehicleEvent.getVehicleId();
+		vehicleEventEntity.type = vehicleEvent.getType();
+		vehicleEventEntity.eventAt = vehicleEvent.getEventAt();
+		vehicleEventEntity.createdAt = vehicleEvent.getCreatedAt();
+		vehicleEventEntity.updatedAt = vehicleEvent.getUpdatedAt();
+		vehicleEventEntity.deletedAt = vehicleEvent.getDeletedAt();
+		return vehicleEventEntity;
+	}
+
+	public VehicleEvent toDomain() {
+		return VehicleEvent.builder()
+			.id(id)
+			.vehicleId(vehicleId)
+			.type(type)
+			.eventAt(eventAt)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleInformationEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleInformationEntity.java
@@ -1,0 +1,81 @@
+package org.controlcenter.vehicle.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.vehicle.domain.VehicleInformation;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "vehicle_information")
+public class VehicleInformationEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "vehicle_id")
+	private Long id;
+
+	private Long vehicleTypeId;
+
+	private String mdn;
+
+	private String tid;
+
+	private Integer mid;
+
+	private Integer pv;
+
+	private Integer did;
+
+	private Integer sum;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static VehicleInformationEntity from(VehicleInformation vehicleInformation) {
+		VehicleInformationEntity vehicleInformationEntity = new VehicleInformationEntity();
+		vehicleInformationEntity.id = vehicleInformation.getId();
+		vehicleInformationEntity.vehicleTypeId = vehicleInformation.getVehicleTypeId();
+		vehicleInformationEntity.mdn = vehicleInformation.getMdn();
+		vehicleInformationEntity.tid = vehicleInformation.getTid();
+		vehicleInformationEntity.mid = vehicleInformation.getMid();
+		vehicleInformationEntity.pv = vehicleInformation.getPv();
+		vehicleInformationEntity.did = vehicleInformation.getDid();
+		vehicleInformationEntity.sum = vehicleInformation.getSum();
+		vehicleInformationEntity.createdAt = vehicleInformation.getCreatedAt();
+		vehicleInformationEntity.updatedAt = vehicleInformation.getUpdatedAt();
+		vehicleInformationEntity.deletedAt = vehicleInformation.getDeletedAt();
+		return vehicleInformationEntity;
+	}
+
+	public VehicleInformation toDomain() {
+		return VehicleInformation.builder()
+			.id(id)
+			.vehicleTypeId(vehicleTypeId)
+			.mdn(mdn)
+			.tid(tid)
+			.mid(mid)
+			.pv(pv)
+			.did(did)
+			.sum(sum)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleInformationEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleInformationEntity.java
@@ -27,7 +27,7 @@ public class VehicleInformationEntity {
 
 	private Long vehicleTypeId;
 
-	private String mdn;
+	private Long mdn;
 
 	private String tid;
 

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleTypeEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleTypeEntity.java
@@ -1,0 +1,57 @@
+package org.controlcenter.vehicle.infrastructure.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.controlcenter.vehicle.domain.VehicleType;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "vehicle_types")
+public class VehicleTypeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "vehicle_types_id")
+	private Long id;
+
+	private String vehicleTypesName;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	private LocalDateTime deletedAt;
+
+	public static VehicleTypeEntity from(VehicleType vehicleType) {
+		VehicleTypeEntity vehicleTypeEntity = new VehicleTypeEntity();
+		vehicleTypeEntity.id = vehicleType.getId();
+		vehicleTypeEntity.vehicleTypesName = vehicleType.getVehicleTypesName();
+		vehicleTypeEntity.createdAt = vehicleType.getCreatedAt();
+		vehicleTypeEntity.updatedAt = vehicleType.getUpdatedAt();
+		vehicleTypeEntity.deletedAt = vehicleType.getDeletedAt();
+		return vehicleTypeEntity;
+	}
+
+	public VehicleType toDomain() {
+		return VehicleType.builder()
+			.id(id)
+			.vehicleTypesName(vehicleTypesName)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.deletedAt(deletedAt)
+			.build();
+	}
+}

--- a/monicar-control-center/src/main/resources/schema/init-schema.sql
+++ b/monicar-control-center/src/main/resources/schema/init-schema.sql
@@ -70,7 +70,7 @@ CREATE TABLE vehicle_information
 (
     `vehicle_id`      BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
     `vehicle_type_id` BIGINT       NOT NULL COMMENT '차종 PK',
-    `mdn`             VARCHAR(255) NOT NULL COMMENT '차량번호',
+    `mdn`             BIGINT NOT NULL COMMENT '차량번호',
     `tid`             VARCHAR(100) NOT NULL COMMENT '터미널 아이디',
     `mid`             INT          NOT NULL COMMENT '제조사 아이디',
     `pv`              INT          NOT NULL COMMENT '패킷버전',

--- a/monicar-control-center/src/main/resources/schema/init-schema.sql
+++ b/monicar-control-center/src/main/resources/schema/init-schema.sql
@@ -109,7 +109,7 @@ CREATE TABLE vehicle_event
 DROP TABLE IF EXISTS cycle_info;
 CREATE TABLE cycle_info
 (
-    `cycle_info_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
+    `cycle_info_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '주기정보 PK',
     `interval_at`   TIMESTAMP    NOT NULL COMMENT '발생시간',
     `status`        VARCHAR(100) NOT NULL COMMENT 'GPS 상태',
     `lat`           DECIMAL      NOT NULL COMMENT '위도 * 1000000 한값(소수점 6자리)',

--- a/monicar-control-center/src/main/resources/schema/init-schema.sql
+++ b/monicar-control-center/src/main/resources/schema/init-schema.sql
@@ -28,7 +28,7 @@ CREATE TABLE manager
     `manager_id`      BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '담당자 PK',
     `department_id`   BIGINT       NOT NULL COMMENT '부서 PK',
     `email`           VARCHAR(255) NOT NULL COMMENT '이메일',
-    `id`              VARCHAR(255) NOT NULL COMMENT '아이디',
+    `login_id`        VARCHAR(255) NOT NULL COMMENT '아이디',
     `password`        VARCHAR(255) NOT NULL COMMENT '비밀번호',
     `nickname`        VARCHAR(255) NOT NULL COMMENT '닉네임',
     `role`            VARCHAR(255) NOT NULL COMMENT '권한',
@@ -39,10 +39,10 @@ CREATE TABLE manager
 ) ENGINE = InnoDB COMMENT ='담당자';
 
 
-DROP TABLE IF EXISTS alert;
-CREATE TABLE alert
+DROP TABLE IF EXISTS alarm;
+CREATE TABLE alarm
 (
-    `alert_id`    BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '알림 PK',
+    `alarm_id`    BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '알림 PK',
     `manager_id`  BIGINT       NOT NULL COMMENT '담당자 PK',
     `description` TEXT         NOT NULL COMMENT '알림 내용',
     `status`      VARCHAR(100) NOT NULL COMMENT '알림 상태',
@@ -68,17 +68,17 @@ CREATE TABLE notice
 DROP TABLE IF EXISTS vehicle_information;
 CREATE TABLE vehicle_information
 (
-    `vehicle_id`       BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
-    `vehicle_types_id` BIGINT       NOT NULL COMMENT '차종 PK',
-    `mdn`              VARCHAR(255) NOT NULL COMMENT '차량번호',
-    `tid`              VARCHAR(100) NOT NULL COMMENT '터미널 아이디',
-    `mid`              INT          NOT NULL COMMENT '제조사 아이디',
-    `pv`               INT          NOT NULL COMMENT '패킷버전',
-    `did`              INT          NOT NULL COMMENT '디바이스 아이디',
-    `sum`              INT          NOT NULL COMMENT '누적 주행 거리',
-    `created_at`       TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
-    `updated_at`       TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
-    `deleted_at`       TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
+    `vehicle_id`      BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
+    `vehicle_type_id` BIGINT       NOT NULL COMMENT '차종 PK',
+    `mdn`             VARCHAR(255) NOT NULL COMMENT '차량번호',
+    `tid`             VARCHAR(100) NOT NULL COMMENT '터미널 아이디',
+    `mid`             INT          NOT NULL COMMENT '제조사 아이디',
+    `pv`              INT          NOT NULL COMMENT '패킷버전',
+    `did`             INT          NOT NULL COMMENT '디바이스 아이디',
+    `sum`             INT          NOT NULL COMMENT '누적 주행 거리',
+    `created_at`      TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
+    `updated_at`      TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
+    `deleted_at`      TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
 ) ENGINE = InnoDB COMMENT ='차량정보';
 
 
@@ -96,28 +96,29 @@ CREATE TABLE vehicle_types
 DROP TABLE IF EXISTS vehicle_event;
 CREATE TABLE vehicle_event
 (
-    `vehicle_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
-    `type`       VARCHAR(100) NOT NULL COMMENT '이벤트 타입',
-    `event_at`   TIMESTAMP    NOT NULL COMMENT '발생 시간',
-    `created_at` TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
-    `updated_at` TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
-    `deleted_at` TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
+    `vehicle_event_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 이벤트 PK',
+    `vehicle_id`       BIGINT       NOT NULL COMMENT '차량 PK',
+    `type`             VARCHAR(100) NOT NULL COMMENT '이벤트 타입',
+    `event_at`         TIMESTAMP    NOT NULL COMMENT '발생 시간',
+    `created_at`       TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
+    `updated_at`       TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
+    `deleted_at`       TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
 ) ENGINE = InnoDB COMMENT ='차량 이벤트';
 
 
-DROP TABLE IF EXISTS gps_information;
-CREATE TABLE gps_information
+DROP TABLE IF EXISTS cycle_info;
+CREATE TABLE cycle_info
 (
-    `vehicle_id`  BIGINT       NOT NULL COMMENT '차량 PK',
-    `interval_at` TIMESTAMP    NOT NULL COMMENT '발생시간',
-    `status`      VARCHAR(100) NOT NULL COMMENT 'GPS 상태',
-    `lat`         DECIMAL      NOT NULL COMMENT '위도 * 1000000 한값(소수점 6자리)',
-    `lon`         DECIMAL      NOT NULL COMMENT '경도 * 1000000 한값(소수점 6자리)',
-    `ang`         INT          NOT NULL COMMENT '방향 - 범위 : 0 ~ 365',
-    `spd`         INT          NOT NULL COMMENT '속도 - 범위 : 0~ 255(단위: km/h)',
-    `created_at`  TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
-    `updated_at`  TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
-    `deleted_at`  TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
+    `cycle_info_id` BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '차량 PK',
+    `interval_at`   TIMESTAMP    NOT NULL COMMENT '발생시간',
+    `status`        VARCHAR(100) NOT NULL COMMENT 'GPS 상태',
+    `lat`           DECIMAL      NOT NULL COMMENT '위도 * 1000000 한값(소수점 6자리)',
+    `lon`           DECIMAL      NOT NULL COMMENT '경도 * 1000000 한값(소수점 6자리)',
+    `ang`           INT          NOT NULL COMMENT '방향 - 범위 : 0 ~ 365',
+    `spd`           INT          NOT NULL COMMENT '속도 - 범위 : 0~ 255(단위: km/h)',
+    `created_at`    TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
+    `updated_at`    TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
+    `deleted_at`    TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
 ) ENGINE = InnoDB COMMENT ='주기 정보';
 
 
@@ -127,7 +128,7 @@ CREATE TABLE driving_history
     `driving_history_id`        BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '운행내역 PK',
     `vehicle_id`                BIGINT       NOT NULL COMMENT '차량 PK',
     `department_id`             BIGINT       NULL COMMENT '부서 PK',
-    `is_business_use`           VARCHAR(100) NOT NULL COMMENT '업무용 확인',
+    `is_business_use`           TINYINT(1)   NOT NULL COMMENT '업무용인지 확인',
     `driver_email`              VARCHAR(255) NOT NULL COMMENT '운전자 이메일',
     `used_at`                   TIMESTAMP    NOT NULL COMMENT '사용일자',
     `initial_odometer`          DOUBLE       NOT NULL COMMENT '주행 전 계기판의 거리(km)',

--- a/monicar-control-center/src/test/java/org/controlcenter/company/application/CompanyServiceTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/company/application/CompanyServiceTest.java
@@ -1,0 +1,51 @@
+package org.controlcenter.company.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.controlcenter.common.exception.BusinessException;
+import org.controlcenter.common.response.code.ErrorCode;
+import org.controlcenter.company.domain.Company;
+import org.controlcenter.company.domain.CompanyCreate;
+import org.controlcenter.company.infrastructure.jpa.CompanyJpaRepository;
+import org.controlcenter.company.infrastructure.jpa.entity.CompanyEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[service 통합테스트] CompanyService")
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CompanyServiceTest {
+
+	@Autowired
+	private CompanyService companyService;
+
+	@Autowired
+	private CompanyJpaRepository companyJpaRepository;
+
+	@DisplayName("이미 등록된 회사이름이 존재한다면, 새로 등록할 수 없다.")
+	@Test
+	void registerWithAlreadyExistsCompanyName() {
+		// given
+		Company company = Company.builder()
+			.companyName("company")
+			.businessRegistrationNumber("A001")
+			.build();
+		companyJpaRepository.save(CompanyEntity.from(company));
+
+		CompanyCreate companyCreate = CompanyCreate.builder()
+			.companyName("company")
+			.businessRegistrationNumber("A002")
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> companyService.register(companyCreate))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.ENTITY_ALREADY_EXIST);
+	}
+}

--- a/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyCreateTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyCreateTest.java
@@ -1,0 +1,45 @@
+package org.controlcenter.company.domain;
+
+import org.controlcenter.common.exception.BusinessException;
+import org.controlcenter.common.response.code.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("[domain 단위테스트] CompanyCreate")
+class CompanyCreateTest {
+
+	@DisplayName("회사를 생성할 수 있다.")
+	@Test
+	void createCompanyCreate() {
+		// given
+		String companyName = "company";
+		String businessRegistrationNumber = "A001";
+
+		// when
+		CompanyCreate companyCreate = CompanyCreate.of(companyName, businessRegistrationNumber);
+
+		// then
+		assertAll(
+			() -> assertThat(companyCreate.getCompanyName()).isEqualTo("company"),
+			() -> assertThat(companyCreate.getBusinessRegistrationNumber()).isEqualTo("A001")
+		);
+	}
+
+	@DisplayName("회사 이름이 10자 초과라면 생성할 수 없다.")
+	@Test
+	void createCompanyCreateWithInvalidCompanyName() {
+		// given
+		String invalidCompanyName = "a".repeat(11);
+		String businessRegistrationNumber = "A001";
+
+		// when & then
+		assertThatThrownBy(() -> CompanyCreate.of(invalidCompanyName, businessRegistrationNumber))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+	}
+}

--- a/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyTest.java
@@ -1,0 +1,25 @@
+package org.controlcenter.company.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DisplayName("[domain 단위테스트] Company")
+class CompanyTest {
+
+	@DisplayName("쿠폰을 생성할 수 있다.")
+	@Test
+	void createCoupon() {
+		// given
+		CompanyCreate companyCreate = CompanyCreate.builder()
+			.companyName("company")
+			.businessRegistrationNumber("A001")
+			.build();
+
+		// when & then
+		assertThatCode(() -> Company.create(companyCreate))
+			.doesNotThrowAnyException();
+	}
+
+}

--- a/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/company/domain/CompanyTest.java
@@ -8,9 +8,9 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 @DisplayName("[domain 단위테스트] Company")
 class CompanyTest {
 
-	@DisplayName("쿠폰을 생성할 수 있다.")
+	@DisplayName("업체를 생성할 수 있다.")
 	@Test
-	void createCoupon() {
+	void createCompany() {
 		// given
 		CompanyCreate companyCreate = CompanyCreate.builder()
 			.companyName("company")

--- a/monicar-control-center/src/test/java/org/controlcenter/company/presentation/CompanyControllerTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/company/presentation/CompanyControllerTest.java
@@ -1,0 +1,134 @@
+package org.controlcenter.company.presentation;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import org.controlcenter.company.application.CompanyService;
+import org.controlcenter.company.domain.Company;
+import org.controlcenter.company.domain.CompanyCreate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@DisplayName("[controller 단위 테스트] CompanyController")
+@WebMvcTest(CompanyController.class)
+class CompanyControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private CompanyService companyService;
+
+	@DisplayName("업체(회사)를 등록할 수 있다.")
+	@Test
+	void register() throws Exception {
+		// given
+		CompanyCreate companyCreate = CompanyCreate.builder()
+			.companyName("company")
+			.businessRegistrationNumber("A001")
+			.build();
+
+		// stubbing
+		Company company = Company.builder()
+			.id(1L)
+			.companyName("company")
+			.businessRegistrationNumber("A001")
+			.createdAt(LocalDateTime.of(2024, 12, 1, 0, 0, 0))
+			.updatedAt(LocalDateTime.of(2024, 12, 1, 0, 0, 0))
+			.deletedAt(null)
+			.build();
+
+		when(companyService.register(any(CompanyCreate.class)))
+			.thenReturn(company);
+
+		// when
+		var result = mockMvc.perform(post("/v1/companies")
+			.content(objectMapper.writeValueAsString(companyCreate))
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result.andDo(print());
+		result.andExpect(status().isOk());
+	}
+
+	static Stream<Arguments> nullTestData() {
+		return Stream.of(
+			Arguments.of(null, "A001"),
+			Arguments.of("company", null)
+		);
+	}
+
+	@DisplayName("쿠폰 등록 요청 시 필드는 null 일 수 없다.")
+	@ParameterizedTest(name = "요청 필드 : {0}, {1}")
+	@MethodSource("nullTestData")
+	void registerCompanyWithNullRequestField(String companyName, String businessRegistrationNumber) throws Exception {
+		// given
+		CompanyCreate companyCreate = CompanyCreate.builder()
+			.companyName(companyName)
+			.businessRegistrationNumber(businessRegistrationNumber)
+			.build();
+
+		// when
+		var result = mockMvc.perform(post("/v1/companies")
+			.content(objectMapper.writeValueAsString(companyCreate))
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result.andDo(print());
+		result.andExpect(status().isOk());
+		result.andExpect(jsonPath("$.isSuccess").value(false));
+		result.andExpect(jsonPath("$.errorCode").value(1000));
+	}
+
+	static Stream<Arguments> emptyTestData() {
+		return Stream.of(
+			Arguments.of("", "A001"),
+			Arguments.of("  ", "A001"),
+			Arguments.of("company", ""),
+			Arguments.of("company", "  ")
+		);
+	}
+
+	@DisplayName("쿠폰 등록 요청 시 필드는 empty 일 수 없다.")
+	@ParameterizedTest(name = "요청 필드 : {0}, {1}")
+	@MethodSource("emptyTestData")
+	void registerCompanyWithEmptyRequestField(String companyName, String businessRegistrationNumber) throws Exception {
+		// given
+		CompanyCreate companyCreate = CompanyCreate.builder()
+			.companyName(companyName)
+			.businessRegistrationNumber(businessRegistrationNumber)
+			.build();
+
+		// when
+		var result = mockMvc.perform(post("/v1/companies")
+			.content(objectMapper.writeValueAsString(companyCreate))
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		result.andDo(print());
+		result.andExpect(status().isOk());
+		result.andExpect(jsonPath("$.isSuccess").value(false));
+		result.andExpect(jsonPath("$.errorCode").value(1000));
+	}
+}

--- a/monicar-control-center/src/test/java/org/controlcenter/jpa/JpaTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/jpa/JpaTest.java
@@ -1,0 +1,425 @@
+package org.controlcenter.jpa;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.controlcenter.alarm.domain.Alarm;
+import org.controlcenter.alarm.domain.AlarmStatus;
+import org.controlcenter.alarm.infrastructure.jpa.AlarmJpaRepository;
+import org.controlcenter.alarm.infrastructure.jpa.entity.AlarmEntity;
+import org.controlcenter.company.domain.Company;
+import org.controlcenter.company.domain.Department;
+import org.controlcenter.company.domain.Manager;
+import org.controlcenter.company.domain.Role;
+import org.controlcenter.company.infrastructure.jpa.CompanyJpaRepository;
+import org.controlcenter.company.infrastructure.jpa.DepartmentJpaRepository;
+import org.controlcenter.company.infrastructure.jpa.ManagerJpaRepository;
+import org.controlcenter.company.infrastructure.jpa.entity.CompanyEntity;
+import org.controlcenter.company.infrastructure.jpa.entity.DepartmentEntity;
+import org.controlcenter.company.infrastructure.jpa.entity.ManagerEntity;
+import org.controlcenter.geoinfo.domain.CycleInfo;
+import org.controlcenter.geoinfo.domain.GpsStatus;
+import org.controlcenter.geoinfo.infrastructure.jpa.CycleInfoJpaRepository;
+import org.controlcenter.geoinfo.infrastructure.jpa.entity.CycleInfoEntity;
+import org.controlcenter.history.domain.DrivingHistory;
+import org.controlcenter.history.infrastructure.jpa.DrivingHistoryJpaRepository;
+import org.controlcenter.history.infrastructure.jpa.entity.DrivingHistoryEntity;
+import org.controlcenter.notice.domain.Notice;
+import org.controlcenter.notice.infrastructure.jpa.NoticeJpaRepository;
+import org.controlcenter.notice.infrastructure.jpa.entity.NoticeEntity;
+import org.controlcenter.vehicle.domain.VehicleEvent;
+import org.controlcenter.vehicle.domain.VehicleEventType;
+import org.controlcenter.vehicle.domain.VehicleInformation;
+import org.controlcenter.vehicle.domain.VehicleType;
+import org.controlcenter.vehicle.infrastructure.jpa.VehicleEventJpaRepository;
+import org.controlcenter.vehicle.infrastructure.jpa.VehicleInformationJpaRepository;
+import org.controlcenter.vehicle.infrastructure.jpa.VehicleTypesJpaRepository;
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleEventEntity;
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleInformationEntity;
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleTypeEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("[infrastructure 테스트] JPA 연결 테스트")
+@ActiveProfiles("test")
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class JpaTest {
+
+	@Autowired
+	private AlarmJpaRepository alarmJpaRepository;
+
+	@Autowired
+	private CompanyJpaRepository companyJpaRepository;
+
+	@Autowired
+	private DepartmentJpaRepository departmentJpaRepository;
+
+	@Autowired
+	private ManagerJpaRepository managerJpaRepository;
+
+	@Autowired
+	private CycleInfoJpaRepository cycleInfoJpaRepository;
+
+	@Autowired
+	private DrivingHistoryJpaRepository drivingHistoryJpaRepository;
+
+	@Autowired
+	private NoticeJpaRepository noticeJpaRepository;
+
+	@Autowired
+	private VehicleEventJpaRepository vehicleEventJpaRepository;
+
+	@Autowired
+	private VehicleInformationJpaRepository vehicleInformationJpaRepository;
+
+	@Autowired
+	private VehicleTypesJpaRepository vehicleTypesJpaRepository;
+
+	@DisplayName("AlarmEntity 테스트")
+	@Test
+	void AlarmEntityTest() {
+		// given
+		Alarm alarm = Alarm.builder()
+			.managerId(100L)
+			.description("test description")
+			.status(AlarmStatus.CHECKED)
+			.deletedAt(null)
+			.build();
+		alarmJpaRepository.save(AlarmEntity.from(alarm));
+
+		// when
+		List<Alarm> Alarms = alarmJpaRepository.findAll().stream()
+			.map(AlarmEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(Alarms).hasSize(1);
+
+		Alarm savedAlarm = Alarms.getFirst();
+
+		assertAll(
+			() -> assertThat(savedAlarm.getId()).isNotNull(),
+			() -> assertThat(savedAlarm.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedAlarm.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedAlarm.getManagerId()).isEqualTo(100L),
+			() -> assertThat(savedAlarm.getDescription()).isEqualTo("test description"),
+			() -> assertThat(savedAlarm.getStatus()).isEqualTo(AlarmStatus.CHECKED)
+		);
+	}
+
+	@DisplayName("CompanyEntity 테스트")
+	@Test
+	void CompanyEntityTest() {
+		// given
+		Company company = Company.builder()
+			.companyName("test company name")
+			.businessRegistrationNumber("999")
+			.deletedAt(null)
+			.build();
+		companyJpaRepository.save(CompanyEntity.from(company));
+
+		// when
+		List<Company> Companies = companyJpaRepository.findAll().stream()
+			.map(CompanyEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(Companies).hasSize(1);
+
+		Company savedCompany = Companies.getFirst();
+
+		assertAll(
+			() -> assertThat(savedCompany.getId()).isNotNull(),
+			() -> assertThat(savedCompany.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedCompany.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedCompany.getCompanyName()).isEqualTo("test company name"),
+			() -> assertThat(savedCompany.getBusinessRegistrationNumber()).isEqualTo("999")
+		);
+	}
+
+	@DisplayName("DepartmentEntity 테스트")
+	@Test
+	void DepartmentEntityTest() {
+		// given
+		Department department = Department.builder()
+			.companyId(999L)
+			.departmentName("test department")
+			.deletedAt(null)
+			.build();
+		departmentJpaRepository.save(DepartmentEntity.from(department));
+
+		// when
+		List<Department> Departments = departmentJpaRepository.findAll().stream()
+			.map(DepartmentEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(Departments).hasSize(1);
+
+		Department savedDepartment = Departments.getFirst();
+
+		assertAll(
+			() -> assertThat(savedDepartment.getId()).isNotNull(),
+			() -> assertThat(savedDepartment.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedDepartment.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedDepartment.getCompanyId()).isEqualTo(999L),
+			() -> assertThat(savedDepartment.getDepartmentName()).isEqualTo("test department")
+		);
+	}
+
+	@DisplayName("ManagerEntity 테스트")
+	@Test
+	void ManagerEntityTest() {
+		// given
+		Manager manager = Manager.builder()
+			.departmentId(999L)
+			.email("test email")
+			.loginId("test login id")
+			.password("test password")
+			.nickname("test nickname")
+			.role(Role.ROLE_ADMIN)
+			.lastLoginedAt(LocalDateTime.now())
+			.deletedAt(null)
+			.build();
+		managerJpaRepository.save(ManagerEntity.from(manager));
+
+		// when
+		List<Manager> managers = managerJpaRepository.findAll().stream()
+			.map(ManagerEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(managers).hasSize(1);
+
+		Manager savedManager = managers.getFirst();
+
+		assertAll(
+			() -> assertThat(savedManager.getId()).isNotNull(),
+			() -> assertThat(savedManager.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedManager.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedManager.getDepartmentId()).isEqualTo(999L),
+			() -> assertThat(savedManager.getEmail()).isEqualTo("test email")
+		);
+	}
+
+	@DisplayName("NoticeEntity 테스트")
+	@Test
+	void NoticeEntityTest() {
+		// given
+		Notice notice = Notice.builder()
+			.title("test title")
+			.content("test content")
+			.imageUrl("test image url")
+			.deletedAt(null)
+			.build();
+		noticeJpaRepository.save(NoticeEntity.from(notice));
+
+		// when
+		List<Notice> notices = noticeJpaRepository.findAll().stream()
+			.map(NoticeEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(notices).hasSize(1);
+
+		Notice savedNotice = notices.getFirst();
+
+		assertAll(
+			() -> assertThat(savedNotice.getId()).isNotNull(),
+			() -> assertThat(savedNotice.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedNotice.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedNotice.getTitle()).isEqualTo("test title"),
+			() -> assertThat(savedNotice.getContent()).isEqualTo("test content"),
+			() -> assertThat(savedNotice.getImageUrl()).isEqualTo("test image url")
+		);
+	}
+
+	@DisplayName("VehicleTypeEntity 테스트")
+	@Test
+	void VehicleTypeEntityTest() {
+		// given
+		VehicleType vehicleType = VehicleType.builder()
+			.vehicleTypesName("test vehicle types name")
+			.deletedAt(null)
+			.build();
+		vehicleTypesJpaRepository.save(VehicleTypeEntity.from(vehicleType));
+
+		// when
+		List<VehicleType> vehicleTypes = vehicleTypesJpaRepository.findAll().stream()
+			.map(VehicleTypeEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(vehicleTypes).hasSize(1);
+
+		VehicleType savedVehicleType = vehicleTypes.getFirst();
+
+		assertAll(
+			() -> assertThat(savedVehicleType.getId()).isNotNull(),
+			() -> assertThat(savedVehicleType.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleType.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleType.getVehicleTypesName()).isEqualTo("test vehicle types name")
+		);
+	}
+
+	@DisplayName("CycleInfoEntity 테스트")
+	@Test
+	void CycleInfoEntityTest() {
+		// given
+		CycleInfo cycleInfo = CycleInfo.builder()
+			.status(GpsStatus.A)
+			.lat(BigDecimal.ONE)
+			.lon(BigDecimal.ONE)
+			.ang(999)
+			.spd(999)
+			.intervalAt(LocalDateTime.now())
+			.deletedAt(null)
+			.build();
+		cycleInfoJpaRepository.save(CycleInfoEntity.from(cycleInfo));
+
+		// when
+		List<CycleInfo> cycleInfos = cycleInfoJpaRepository.findAll().stream()
+			.map(CycleInfoEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(cycleInfos).hasSize(1);
+
+		CycleInfo savedCycleInfo = cycleInfos.getFirst();
+
+		assertAll(
+			() -> assertThat(savedCycleInfo.getId()).isNotNull(),
+			() -> assertThat(savedCycleInfo.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedCycleInfo.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedCycleInfo.getStatus()).isEqualTo(GpsStatus.A),
+			() -> assertThat(savedCycleInfo.getLat()).isEqualTo(BigDecimal.ONE),
+			() -> assertThat(savedCycleInfo.getLon()).isEqualTo(BigDecimal.ONE),
+			() -> assertThat(savedCycleInfo.getAng()).isEqualTo(999),
+			() -> assertThat(savedCycleInfo.getSpd()).isEqualTo(999)
+		);
+	}
+
+	@DisplayName("VehicleInformationEntity 테스트")
+	@Test
+	void VehicleInformationEntityTest() {
+		// given
+		VehicleInformation vehicleInformation = VehicleInformation.builder()
+			.vehicleTypeId(999L)
+			.mdn("test mdn")
+			.tid("test tid")
+			.mid(999)
+			.pv(999)
+			.did(999)
+			.sum(999)
+			.deletedAt(null)
+			.build();
+		vehicleInformationJpaRepository.save(VehicleInformationEntity.from(vehicleInformation));
+
+		// when
+		List<VehicleInformation> vehicleInformations = vehicleInformationJpaRepository.findAll().stream()
+			.map(VehicleInformationEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(vehicleInformations).hasSize(1);
+
+		VehicleInformation savedVehicleInformation = vehicleInformations.getFirst();
+
+		assertAll(
+			() -> assertThat(savedVehicleInformation.getId()).isNotNull(),
+			() -> assertThat(savedVehicleInformation.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleInformation.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleInformation.getMdn()).isEqualTo("test mdn"),
+			() -> assertThat(savedVehicleInformation.getTid()).isEqualTo("test tid"),
+			() -> assertThat(savedVehicleInformation.getMid()).isEqualTo(999),
+			() -> assertThat(savedVehicleInformation.getPv()).isEqualTo(999),
+			() -> assertThat(savedVehicleInformation.getDid()).isEqualTo(999),
+			() -> assertThat(savedVehicleInformation.getSum()).isEqualTo(999)
+		);
+	}
+
+	@DisplayName("VehicleEventEntity 테스트")
+	@Test
+	void VehicleEventEntityTest() {
+		// given
+		VehicleEvent vehicleEvent = VehicleEvent.builder()
+			.vehicleId(999L)
+			.type(VehicleEventType.ON)
+			.eventAt(LocalDateTime.now())
+			.deletedAt(null)
+			.build();
+		vehicleEventJpaRepository.save(VehicleEventEntity.from(vehicleEvent));
+
+		// when
+		List<VehicleEvent> vehicleEvents = vehicleEventJpaRepository.findAll().stream()
+			.map(VehicleEventEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(vehicleEvents).hasSize(1);
+
+		VehicleEvent savedVehicleEvent = vehicleEvents.getFirst();
+
+		assertAll(
+			() -> assertThat(savedVehicleEvent.getId()).isNotNull(),
+			() -> assertThat(savedVehicleEvent.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleEvent.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedVehicleEvent.getVehicleId()).isEqualTo(999L),
+			() -> assertThat(savedVehicleEvent.getType()).isEqualTo(VehicleEventType.ON)
+		);
+	}
+
+	@DisplayName("DrivingHistoryEntity 테스트")
+	@Test
+	void DrivingHistoryEntityTest() {
+		// given
+		DrivingHistory drivingHistory = DrivingHistory.builder()
+			.vehicleId(999L)
+			.departmentId(999L)
+			.driverEmail("test driver email")
+			.initialOdometer(100.0)
+			.finalOdometer(100.0)
+			.drivingDistance(100.0)
+			.businessCommuteDistance(100.0)
+			.businessUsageDistance(100.0)
+			.isBusinessUse(true)
+			.usedAt(LocalDateTime.now())
+			.onTime(LocalDateTime.now())
+			.offTime(LocalDateTime.now())
+			.deletedAt(null)
+			.build();
+		drivingHistoryJpaRepository.save(DrivingHistoryEntity.from(drivingHistory));
+
+		// when
+		List<DrivingHistory> drivingHistories = drivingHistoryJpaRepository.findAll().stream()
+			.map(DrivingHistoryEntity::toDomain)
+			.toList();
+
+		// then
+		assertThat(drivingHistories).hasSize(1);
+
+		DrivingHistory savedDrivingHistory = drivingHistories.getFirst();
+
+		assertAll(
+			() -> assertThat(savedDrivingHistory.getId()).isNotNull(),
+			() -> assertThat(savedDrivingHistory.getCreatedAt()).isNotNull(),
+			() -> assertThat(savedDrivingHistory.getUpdatedAt()).isNotNull(),
+			() -> assertThat(savedDrivingHistory.getDriverEmail()).isEqualTo("test driver email"),
+			() -> assertThat(savedDrivingHistory.getInitialOdometer()).isEqualTo(100.0),
+			() -> assertThat(savedDrivingHistory.getFinalOdometer()).isEqualTo(100.0),
+			() -> assertThat(savedDrivingHistory.getDrivingDistance()).isEqualTo(100.0),
+			() -> assertThat(savedDrivingHistory.getBusinessCommuteDistance()).isEqualTo(100.0),
+			() -> assertThat(savedDrivingHistory.getBusinessUsageDistance()).isEqualTo(100.0),
+			() -> assertThat(savedDrivingHistory.getIsBusinessUse()).isEqualTo(true)
+		);
+	}
+}

--- a/monicar-control-center/src/test/resources/application-test.yml
+++ b/monicar-control-center/src/test/resources/application-test.yml
@@ -2,6 +2,7 @@ spring:
   datasource:
     url: jdbc:tc:mysql:8.0.36:///?useSSL=false&serverTimezone=Asia/Seoul
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+
   jpa:
     show-sql: true
     properties:

--- a/monicar-control-center/src/test/resources/application-test.yml
+++ b/monicar-control-center/src/test/resources/application-test.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:tc:mysql:8.0.36:///?useSSL=false&serverTimezone=Asia/Seoul
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    hibernate:
+      ddl-auto: none
+
+  test:
+    database:
+      replace: none
+
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:/schema/init-schema.sql

--- a/monicar-track-alert/build.gradle
+++ b/monicar-track-alert/build.gradle
@@ -1,0 +1,16 @@
+dependencies {
+    implementation project(':monicar-control-center')
+
+    implementation "org.springframework.boot:spring-boot-starter-web"
+    implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
+}
+
+tasks.bootJar {
+    enabled = true
+}
+
+tasks.jar {
+    enabled = true
+}

--- a/monicar-track-alert/src/main/java/org/trackalert/TrackAlertApplication.java
+++ b/monicar-track-alert/src/main/java/org/trackalert/TrackAlertApplication.java
@@ -1,0 +1,11 @@
+package org.trackalert;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TrackAlertApplication {
+	public static void main(String[] args) {
+		SpringApplication.run(TrackAlertApplication.class, args);
+	}
+}

--- a/monicar-track-alert/src/main/java/org/trackalert/application/TrackAlertService.java
+++ b/monicar-track-alert/src/main/java/org/trackalert/application/TrackAlertService.java
@@ -1,0 +1,4 @@
+package org.trackalert.application;
+
+public class TrackAlertService {
+}

--- a/monicar-track-alert/src/main/java/org/trackalert/application/port/TrackAlertRepository.java
+++ b/monicar-track-alert/src/main/java/org/trackalert/application/port/TrackAlertRepository.java
@@ -1,0 +1,4 @@
+package org.trackalert.application.port;
+
+public interface TrackAlertRepository {
+}

--- a/monicar-track-alert/src/main/java/org/trackalert/domain/command/TrackAlertCreate.java
+++ b/monicar-track-alert/src/main/java/org/trackalert/domain/command/TrackAlertCreate.java
@@ -1,0 +1,4 @@
+package org.trackalert.domain.command;
+
+public class TrackAlertCreate {
+}

--- a/monicar-track-alert/src/main/java/org/trackalert/presentation/TrackAlertController.java
+++ b/monicar-track-alert/src/main/java/org/trackalert/presentation/TrackAlertController.java
@@ -1,0 +1,4 @@
+package org.trackalert.presentation;
+
+public class TrackAlertController {
+}

--- a/monicar-track-alert/src/main/java/org/trackalert/presentation/request/TrackAlertCreateRequest.java
+++ b/monicar-track-alert/src/main/java/org/trackalert/presentation/request/TrackAlertCreateRequest.java
@@ -1,0 +1,4 @@
+package org.trackalert.presentation.request;
+
+public class TrackAlertCreateRequest {
+}

--- a/monicar-track-alert/src/main/java/org/trackalert/presentation/response/TrackAlertSimpleResponse.java
+++ b/monicar-track-alert/src/main/java/org/trackalert/presentation/response/TrackAlertSimpleResponse.java
@@ -1,0 +1,4 @@
+package org.trackalert.presentation.response;
+
+public class TrackAlertSimpleResponse {
+}

--- a/monicar-track-alert/src/main/resources/application-dev.yml
+++ b/monicar-track-alert/src/main/resources/application-dev.yml
@@ -1,0 +1,23 @@
+server:
+  port: 8082
+
+spring:
+  application:
+    name: monicar-track-alert
+
+  config:
+    activate:
+      on-profile: dev
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    hibernate:
+      ddl-auto: none
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/monicar_db
+    username: local_user
+    password: local_password

--- a/monicar-track-alert/src/main/resources/application.yml
+++ b/monicar-track-alert/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: dev

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@ include 'monicar-emulator'
 include 'monicar-control-center'
 include 'monicar-collector'
 include 'monicar-common'
+include 'monicar-track-alert'
 


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

- vehicleInformation 도메인 추가
- collector모듈 내에 Producer, Consumer구현
- 주기정보 저장 시, 기존에 있는 차량정보 데이터를 바탕으로 mdn데이터 반환하도록 변경

## #️⃣ 연관된 이슈

#58 

## 💡 리뷰어에게 하고 싶은 말

### mdn 타입을 String -> Long으로 변경

### service 로직을 변경한 이유
주기정보 단건 저장시 sevice로직을 아래와 같이 변경한 이유는 다음과 같습니다.
1. 시동 on정보 -> 주기정보 -> 시동off순으로 정보 수신. 
2. 시동 on정보가 올바르게 수신 되었다면, 그에 따라 차량번호(mdn)가 DB에 저장
3. DB에 이미 차량번호(mdn)이 있기 때문에 해당 차량번호를 토대로 차량정보(VehicleInformation) 저장 
4. 주기정보 저장

위 흐름대로 진행될 것이라고 생각하였기 때문에 service로직을 수정하였습니다. 

### Kafka설정 정보
- 브로커 3개 설정
- key를 String타입의 mdn으로 설정
- Producer의 key, value 직렬화 -> String, Json으로 하도록 설정
- Consumer의 key, value 직렬화 -> String, Json으로 하도록 설정
- topic자동으로 생성되지 않도록 금지
- Producer의 acks를 1로 설정함으로써 리더파티션이 받았다고 하면 응답, 리더파티션으로부터 응답이 오지 않으면 retry하도록 설정

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인