### PR TITLE
[Feature] collector모듈 내에 Producer, Consumer구현

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,5 +14,123 @@ services:
       TZ: ${DEV_MYSQL_TIME_ZONE}
     networks:
       - monicar
+  zookeeper:
+    image: 'bitnami/zookeeper:3.7.2'
+    container_name: zookeeper
+    ports:
+      - 2181:2181
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    volumes:
+      - ./.data/zookeeper/data:/bitnami/zookeeper/data
+      - ./.data/zookeeper/datalog:/bitnami/zookeeper/datalog
+      - ./.data/zookeeper/logs:/bitnami/zookeeper/logs
+    networks:
+      - monicar
+  kafka1:
+    image: 'bitnami/kafka:3.6.0'
+    container_name: kafka1
+    hostname: kafka1
+    ports:
+      - 19092
+      - "9092:9092"
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=CLIENT://:19092,EXTERNAL://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka1:19092,EXTERNAL://localhost:9092
+      - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+    depends_on:
+      - zookeeper
+    volumes:
+      - ./.data/kafka1:/bitnami/kafka/data
+    networks:
+      - monicar
+  kafka2:
+    image: 'bitnami/kafka:3.6.0'
+    container_name: kafka2
+    ports:
+      - 19092
+      - "9093:9093"
+    environment:
+      - KAFKA_BROKER_ID=2
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=CLIENT://:19092,EXTERNAL://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka2:19092,EXTERNAL://localhost:9093
+      - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+    depends_on:
+      - zookeeper
+    volumes:
+      - ./.data/kafka2:/bitnami/kafka/data
+    networks:
+      - monicar
+  kafka3:
+    image: 'bitnami/kafka:3.6.0'
+    container_name: kafka3
+    ports:
+      - 19092
+      - "9094:9094"
+    environment:
+      - KAFKA_BROKER_ID=3
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=CLIENT://:19092,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka3:19092,EXTERNAL://localhost:9094
+      - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+    depends_on:
+      - zookeeper
+    volumes:
+      - ./.data/kafka3:/bitnami/kafka/data
+    networks:
+      - monicar
+  kafka-ui:
+    image: 'provectuslabs/kafka-ui:v0.7.1'
+    container_name: kafka-ui
+    ports:
+      - "9091:8080"
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka1:19092,kafka2:19092,kafka3:19092
+    depends_on:
+      - zookeeper
+      - kafka1
+      - kafka2
+      - kafka3
+    networks:
+      - monicar
+  cmak:
+    image: 'hlebalbau/kafka-manager:3.0.0.5'
+    container_name: cmak
+    ports:
+      - "9000:9000"
+    environment:
+      - ZK_HOSTS=zookeeper:2181
+    depends_on:
+      - zookeeper
+      - kafka1
+      - kafka2
+      - kafka3
+    networks:
+      - monicar
+  redpanda-console:
+    image: 'docker.redpanda.com/redpandadata/console:v2.3.7'
+    container_name: redpanda-console
+    ports:
+      - "8989:8080"
+    environment:
+      - KAFKA_BROKERS=kafka1:19092,kafka2:19092,kafka3:19092
+    depends_on:
+      - zookeeper
+      - kafka1
+      - kafka2
+      - kafka3
+    networks:
+      - monicar
 networks:
   monicar:
+    driver: bridge

--- a/monicar-collector/build.gradle
+++ b/monicar-collector/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "com.mysql:mysql-connector-j"
+    implementation "org.springframework.kafka:spring-kafka:3.3.0"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation project(':monicar-common')
 }

--- a/monicar-collector/src/main/java/org/collector/application/CycleInfoService.java
+++ b/monicar-collector/src/main/java/org/collector/application/CycleInfoService.java
@@ -3,7 +3,10 @@ package org.collector.application;
 import java.util.List;
 
 import org.collector.domain.CycleInfo;
+import org.collector.domain.VehicleInformation;
 import org.collector.infrastructure.repository.CycleInfoRepository;
+import org.collector.infrastructure.repository.VehicleInformationRepository;
+import org.collector.presentation.dto.CListRequest;
 import org.collector.presentation.dto.CycleInfoRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,23 +17,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CycleInfoService {
 	private final CycleInfoRepository cycleInfoRepository;
+	private final VehicleInformationRepository vehicleInformationRepository;
 
 	@Transactional
-	public void cycleInfoSave(final CycleInfoRequest request) {
+	public long cycleInfoSave(final CycleInfoRequest request) {
+		VehicleInformation vehicleInformation = vehicleInformationRepository.findByMdn(request.mdn())
+			.orElseThrow(IllegalArgumentException::new);
+
+		CycleInfoRequest.from(request);
+
+		vehicleInformationRepository.save(vehicleInformation);
+
 		List<CycleInfo> cycleInfos = request.cList().stream()
-			.map(cListRequest -> CycleInfo.builder()
-				.interval_at(cListRequest.interval_at())
-				.gcd(cListRequest.gcd())
-				.lat(CycleInfo.convertToSixDecimalPlaces(cListRequest.lat()))
-				.lon(CycleInfo.convertToSixDecimalPlaces(cListRequest.lon()))
-				.ang(cListRequest.ang())
-				.spd(cListRequest.spd())
-				.sum(cListRequest.sum())
-				.bat(cListRequest.bat())
-				.build()
-			)
+			.map(cListRequest -> CListRequest.from(cListRequest, vehicleInformation))
 			.toList();
 
 		cycleInfoRepository.saveAll(cycleInfos);
+		return vehicleInformation.getMdn();
 	}
 }

--- a/monicar-collector/src/main/java/org/collector/common/response/CommonResponse.java
+++ b/monicar-collector/src/main/java/org/collector/common/response/CommonResponse.java
@@ -11,8 +11,8 @@ public record CommonResponse<T>(
 	Object rstMsg,
 	String mdn
 ) {
-	public static <T> CommonResponse<T> ok(@Nullable final String mdn) {
-		return new CommonResponse<>(ResponseCode.SUCCESS.getCode(), ResponseCode.SUCCESS.getMessage(), mdn);
+	public static <T> CommonResponse<T> ok(final long mdn) {
+		return new CommonResponse<>(ResponseCode.SUCCESS.getCode(), ResponseCode.SUCCESS.getMessage(), Long.toString(mdn));
 	}
 
 	public static <T> CommonResponse<T> fail(final CustomException e, @Nullable final String mdn) {

--- a/monicar-collector/src/main/java/org/collector/config/KafkaConfig.java
+++ b/monicar-collector/src/main/java/org/collector/config/KafkaConfig.java
@@ -1,0 +1,68 @@
+package org.collector.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+public class KafkaConfig {
+
+	@Bean
+	@Primary
+	@ConfigurationProperties("spring.kafka")
+	public KafkaProperties kafkaProperties() {
+		return new KafkaProperties();
+	}
+
+	@Bean
+	public ConsumerFactory<String, Object> consumerFactory(KafkaProperties kafkaProperties) {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, kafkaProperties.getConsumer().getKeyDeserializer());
+		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, kafkaProperties.getConsumer().getValueDeserializer());
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+		props.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false");
+		return new DefaultKafkaConsumerFactory<>(props);
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
+		ConsumerFactory<String, Object> consumerFactory
+	) {
+		ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(consumerFactory);
+		factory.setConcurrency(1);
+
+		return factory;
+	}
+
+	@Bean
+	public ProducerFactory<String, Object> producerFactory(KafkaProperties kafkaProperties) {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getKeySerializer());
+		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getValueSerializer());
+		props.put(ProducerConfig.ACKS_CONFIG, kafkaProperties.getProducer().getAcks());
+		return new DefaultKafkaProducerFactory<>(props);
+	}
+
+	@Bean
+	public KafkaTemplate<String, ?> kafkaTemplate(KafkaProperties kafkaProperties) {
+		return new KafkaTemplate<>(producerFactory(kafkaProperties));
+	}
+}

--- a/monicar-collector/src/main/java/org/collector/consumer/CycleInfoConsumer.java
+++ b/monicar-collector/src/main/java/org/collector/consumer/CycleInfoConsumer.java
@@ -1,0 +1,18 @@
+package org.collector.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.collector.presentation.dto.CycleInfoRequest;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CycleInfoConsumer {
+
+	@KafkaListener(
+		topics = { "cycleInfo-json-topic" },
+		groupId = "consumer-group"
+	)
+	public void accept(ConsumerRecord<String, CycleInfoRequest> message) {
+		System.out.println("[Main Consumer] Message arrived! - " + message.value());
+	}
+}

--- a/monicar-collector/src/main/java/org/collector/domain/CycleInfo.java
+++ b/monicar-collector/src/main/java/org/collector/domain/CycleInfo.java
@@ -50,7 +50,7 @@ public class CycleInfo implements Serializable {
 	private int bat;
 	@ManyToOne
 	@JoinColumn(name = "vehicle_id")
-	private Vehicle vehicle;
+	private VehicleInformation vehicleInformation;
 
 	public static BigDecimal convertToSixDecimalPlaces(Double value) {
 		return BigDecimal.valueOf(value / 1000000.0);

--- a/monicar-collector/src/main/java/org/collector/domain/VehicleInformation.java
+++ b/monicar-collector/src/main/java/org/collector/domain/VehicleInformation.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Vehicle implements Serializable {
+public class VehicleInformation implements Serializable {
 	@Serial
 	private static final long serialVersionUID = 1L;
 	@Id

--- a/monicar-collector/src/main/java/org/collector/infrastructure/repository/VehicleInformationRepository.java
+++ b/monicar-collector/src/main/java/org/collector/infrastructure/repository/VehicleInformationRepository.java
@@ -1,0 +1,10 @@
+package org.collector.infrastructure.repository;
+
+import java.util.Optional;
+
+import org.collector.domain.VehicleInformation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VehicleInformationRepository extends JpaRepository<VehicleInformation, Long> {
+	Optional<VehicleInformation> findByMdn(Long mdn);
+}

--- a/monicar-collector/src/main/java/org/collector/presentation/CycleInfoController.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/CycleInfoController.java
@@ -3,6 +3,7 @@ package org.collector.presentation;
 import org.collector.application.CycleInfoService;
 import org.collector.common.response.CommonResponse;
 import org.collector.presentation.dto.CycleInfoRequest;
+import org.collector.producer.CycleInfoProducer;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,11 +17,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CycleInfoController {
 
+	private final CycleInfoProducer cycleInfoProducer;
 	private final CycleInfoService cycleInfoService;
 
 	@PostMapping
 	public CommonResponse<Void> cycleInfoSave(final @Valid @RequestBody CycleInfoRequest request) {
-		cycleInfoService.cycleInfoSave(request);
-		return CommonResponse.ok("111");
+		cycleInfoProducer.sendMessage(request);
+		long mdn = cycleInfoService.cycleInfoSave(request);
+		return CommonResponse.ok(mdn);
 	}
 }

--- a/monicar-collector/src/main/java/org/collector/presentation/CycleInfoController.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/CycleInfoController.java
@@ -22,8 +22,8 @@ public class CycleInfoController {
 
 	@PostMapping
 	public CommonResponse<Void> cycleInfoSave(final @Valid @RequestBody CycleInfoRequest request) {
-		cycleInfoProducer.sendMessage(request);
 		long mdn = cycleInfoService.cycleInfoSave(request);
+		cycleInfoProducer.sendMessage(request);
 		return CommonResponse.ok(mdn);
 	}
 }

--- a/monicar-collector/src/main/java/org/collector/presentation/dto/CListRequest.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/dto/CListRequest.java
@@ -2,6 +2,8 @@ package org.collector.presentation.dto;
 
 import java.time.LocalDateTime;
 
+import org.collector.domain.CycleInfo;
+import org.collector.domain.VehicleInformation;
 import org.hibernate.validator.constraints.Range;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -38,4 +40,17 @@ public record CListRequest(
 	@Range(min = 0, max = 9999, message = "배터리 전압은 0 ~ 9999 사이여야 합니다.")
 	Integer bat
 ) {
+	public static CycleInfo from(CListRequest request, VehicleInformation vehicleInformation) {
+		return CycleInfo.builder()
+			.interval_at(request.interval_at())
+			.gcd(request.gcd())
+			.lat(CycleInfo.convertToSixDecimalPlaces(request.lat()))
+			.lon(CycleInfo.convertToSixDecimalPlaces(request.lon()))
+			.ang(request.ang())
+			.spd(request.spd())
+			.sum(request.sum())
+			.bat(request.bat())
+			.vehicleInformation(vehicleInformation)
+			.build();
+	}
 }

--- a/monicar-collector/src/main/java/org/collector/presentation/dto/CycleInfoRequest.java
+++ b/monicar-collector/src/main/java/org/collector/presentation/dto/CycleInfoRequest.java
@@ -3,6 +3,7 @@ package org.collector.presentation.dto;
 import java.util.List;
 
 import org.collector.common.annotation.MatchCycleSize;
+import org.collector.domain.VehicleInformation;
 import org.hibernate.validator.constraints.Range;
 
 import jakarta.validation.Valid;
@@ -33,4 +34,13 @@ public record CycleInfoRequest(
 	@Valid
 	List<CListRequest> cList
 ) {
+	public static VehicleInformation from(CycleInfoRequest request) {
+		return VehicleInformation.builder()
+			.mdn(request.mdn())
+			.tid(request.tid())
+			.mid(request.mid())
+			.pv(request.pv())
+			.did(request.did())
+			.build();
+	}
 }

--- a/monicar-collector/src/main/java/org/collector/producer/CycleInfoProducer.java
+++ b/monicar-collector/src/main/java/org/collector/producer/CycleInfoProducer.java
@@ -1,0 +1,20 @@
+package org.collector.producer;
+
+import org.collector.presentation.dto.CycleInfoRequest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class CycleInfoProducer {
+	private final KafkaTemplate<String, CycleInfoRequest> kafkaTemplate;
+
+	public void sendMessage(CycleInfoRequest message) {
+		log.info("send message: {}", message);
+		kafkaTemplate.send("cycleInfo-json-topic", String.valueOf(message.mdn()), message);
+	}
+}

--- a/monicar-collector/src/main/resources/application.yml
+++ b/monicar-collector/src/main/resources/application.yml
@@ -5,11 +5,15 @@ spring:
   application:
     name: monicar-collector
 
+    #  datasource:
+    #    driver-class-name: com.mysql.cj.jdbc.Driver
+    #    url: jdbc:mysql://localhost:3306/monicar?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    #    username: root
+    #    password:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/monicar?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: root
-    password:
+    url: jdbc:mysql://localhost:3306/monicar_db
+    username: local_user
+    password: local_password
 
 
   jpa:
@@ -20,6 +24,19 @@ spring:
     properties:
       hibernate.format_sql: true
       dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+
+  kafka:
+    bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      auto-offset-reset: latest
+    listener:
+      concurrency: 1
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: 1
 
 
 logging:


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

- vehicleInformation 도메인 추가
- collector모듈 내에 Producer, Consumer구현
- 주기정보 저장 시, 기존에 있는 차량정보 데이터를 바탕으로 mdn데이터 반환하도록 변경

## #️⃣ 연관된 이슈

#58 

## 💡 리뷰어에게 하고 싶은 말

### mdn 타입을 String -> Long으로 변경

### service 로직을 변경한 이유
주기정보 단건 저장시 sevice로직을 아래와 같이 변경한 이유는 다음과 같습니다.
1. 시동 on정보 -> 주기정보 -> 시동off순으로 정보 수신. 
2. 시동 on정보가 올바르게 수신 되었다면, 그에 따라 차량번호(mdn)가 DB에 저장
3. DB에 이미 차량번호(mdn)이 있기 때문에 해당 차량번호를 토대로 차량정보(VehicleInformation) 저장 
4. 주기정보 저장

위 흐름대로 진행될 것이라고 생각하였기 때문에 service로직을 수정하였습니다. 

### Kafka설정 정보
- 브로커 3개 설정
- key를 String타입의 mdn으로 설정
- Producer의 key, value 직렬화 -> String, Json으로 하도록 설정
- Consumer의 key, value 역직렬화 -> String, Json으로 하도록 설정
- topic자동으로 생성되지 않도록 금지
- Producer의 acks를 1로 설정함으로써 리더파티션이 받았다고 하면 응답, 리더파티션으로부터 응답이 오지 않으면 retry하도록 설정

### `localhost:9091` 을 통해 topic에 메시지가 올바르게 저장되었는지 확인하실 수 있습니다. 
<img width="1728" alt="스크린샷 2025-01-06 오전 11 19 29" src="https://github.com/user-attachments/assets/fc679522-02c4-45a3-a2f0-007830af3c0e" />



**Kafka 관련 설정은 이후 계속 보완할 예정입니다. 메시지를 주고 받을 수 있도록 하는 것에 의의를 두었습니다.**

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인