### PR TITLE
feature: 주기 정보 요청 비동기 이벤트 처리

### DIFF
--- a/monicar-emulator/build.gradle
+++ b/monicar-emulator/build.gradle
@@ -1,7 +1,10 @@
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
+    implementation "org.springframework.boot:spring-boot-starter-validation"
+
     implementation 'org.springframework:spring-aspects'
     implementation 'org.springframework.retry:spring-retry'
+    implementation "org.springframework.kafka:spring-kafka:3.3.0"
 
     testImplementation 'org.mock-server:mockserver-netty:5.15.0'
 

--- a/monicar-emulator/lombok.config
+++ b/monicar-emulator/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/monicar-emulator/lombok.config
+++ b/monicar-emulator/lombok.config
@@ -1,1 +1,0 @@
-lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/monicar-emulator/src/main/java/org/emulator/config/AsyncConfig.java
+++ b/monicar-emulator/src/main/java/org/emulator/config/AsyncConfig.java
@@ -1,9 +1,21 @@
 package org.emulator.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @EnableAsync
 @Configuration
 public class AsyncConfig {
+	@Bean
+	public ThreadPoolTaskExecutor taskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(5);
+		executor.setMaxPoolSize(10);
+		executor.setQueueCapacity(20);
+		executor.setThreadNamePrefix("AsyncExecutor-");
+		executor.initialize();
+		return executor;
+	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/config/JacksonConfig.java
+++ b/monicar-emulator/src/main/java/org/emulator/config/JacksonConfig.java
@@ -1,0 +1,21 @@
+package org.emulator.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+	@Bean
+	public ObjectMapper objectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		return objectMapper;
+	}
+}
+
+

--- a/monicar-emulator/src/main/java/org/emulator/config/KafkaConfig.java
+++ b/monicar-emulator/src/main/java/org/emulator/config/KafkaConfig.java
@@ -1,0 +1,39 @@
+package org.emulator.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaConfig {
+
+	@Bean
+	@Primary
+	@ConfigurationProperties("spring.kafka")
+	public KafkaProperties kafkaProperties() {
+		return new KafkaProperties();
+	}
+
+	@Bean
+	public ProducerFactory<String, Object> producerFactory(KafkaProperties kafkaProperties) {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getKeySerializer());
+		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getValueSerializer());
+		return new DefaultKafkaProducerFactory<>(props);
+	}
+
+	@Bean
+	public KafkaTemplate<String, Object> kafkaTemplate(KafkaProperties kafkaProperties) {
+		return new KafkaTemplate<>(producerFactory(kafkaProperties));
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/config/KafkaConfig.java
+++ b/monicar-emulator/src/main/java/org/emulator/config/KafkaConfig.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.emulator.device.infrastructure.external.command.CycleInfoListCommand;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -24,7 +25,7 @@ public class KafkaConfig {
 	}
 
 	@Bean
-	public ProducerFactory<String, Object> producerFactory(KafkaProperties kafkaProperties) {
+	public ProducerFactory<String, CycleInfoListCommand> producerFactory(KafkaProperties kafkaProperties) {
 		Map<String, Object> props = new HashMap<>();
 		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
 		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getKeySerializer());
@@ -33,7 +34,7 @@ public class KafkaConfig {
 	}
 
 	@Bean
-	public KafkaTemplate<String, Object> kafkaTemplate(KafkaProperties kafkaProperties) {
+	public KafkaTemplate<String, CycleInfoListCommand> kafkaTemplate(KafkaProperties kafkaProperties) {
 		return new KafkaTemplate<>(producerFactory(kafkaProperties));
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/VehicleConstant.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/VehicleConstant.java
@@ -6,6 +6,7 @@ public final class VehicleConstant {
 	public static final String MANUFACTURER_ID = "6";
 	public static final String PACKET_VERSION = "5";
 	public static final String DEVICE_ID = "1";
+	public static final int BATTERY = 100;
 	public static final long MIL = 1000_000;
 
 	private VehicleConstant() {

--- a/monicar-emulator/src/main/java/org/emulator/device/VehicleConstant.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/VehicleConstant.java
@@ -1,15 +1,17 @@
 package org.emulator.device;
 
 public final class VehicleConstant {
-	public static final String VEHICLE_NUM = "01234567890";
+	public static final long VEHICLE_PRIMARY_KEY = 1234567890L;
+	public static final String VEHICLE_NUMBER = "12나3456";
 	public static final String TERMINAL_ID = "A001";
-	public static final String MANUFACTURER_ID = "6";
-	public static final String PACKET_VERSION = "5";
-	public static final String DEVICE_ID = "1";
+	public static final long MANUFACTURER_ID = 6L;
+	public static final int PACKET_VERSION = 5;
+	public static final long DEVICE_ID = 1L;
 	public static final int BATTERY = 100;
-	public static final long MIL = 1000_000;
+
+	public static final long MIL = 1_000_000;
 
 	private VehicleConstant() {
-		throw new AssertionError();
+		throw new IllegalAccessError("Constant class");
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/application/VehicleService.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/application/VehicleService.java
@@ -1,6 +1,5 @@
 package org.emulator.device.application;
 
-import java.time.LocalDateTime;
 import java.util.Deque;
 import java.util.LinkedList;
 
@@ -11,7 +10,7 @@ import org.emulator.device.application.port.VehicleCommandSender;
 import org.emulator.device.domain.CycleInfo;
 import org.emulator.device.domain.GpsStatus;
 import org.emulator.device.domain.OnInfo;
-import org.emulator.pipe.Gps;
+import org.emulator.device.infrastructure.GpsTime;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -27,13 +26,13 @@ public class VehicleService {
 	private static final Deque<CycleInfo> cycleInfos = new LinkedList<>();
 
 	public void onVehicle() {
-		Gps onLocation = locationReceiver.getLocation();
+		GpsTime onLocation = locationReceiver.getLocation();
 
 		OnInfo onInfo = OnInfo.create(
-			LocalDateTime.now(),
+			onLocation.intervalAt(),
 			GpsStatus.A,
-			onLocation.lat(),
-			onLocation.lon(),
+			onLocation.location().lat(),
+			onLocation.location().lon(),
 			emulatorRepository.getTotalDistance()
 		);
 

--- a/monicar-emulator/src/main/java/org/emulator/device/application/VehicleService.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/application/VehicleService.java
@@ -1,13 +1,9 @@
 package org.emulator.device.application;
 
-import java.util.Deque;
-import java.util.LinkedList;
-
 import org.common.dto.CommonResponse;
 import org.emulator.device.application.port.EmulatorRepository;
 import org.emulator.device.application.port.LocationReceiver;
 import org.emulator.device.application.port.VehicleCommandSender;
-import org.emulator.device.domain.CycleInfo;
 import org.emulator.device.domain.GpsStatus;
 import org.emulator.device.domain.OnInfo;
 import org.emulator.device.infrastructure.GpsTime;
@@ -20,10 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class VehicleService {
 	private final EmulatorRepository emulatorRepository;
 	private final LocationReceiver locationReceiver;
-	// private final LocationEventPublisher locationEventPublisher; // 추후 주기 정보를 이벤트로 쏠 때
 	private final VehicleCommandSender vehicleCommandSender;
-
-	private static final Deque<CycleInfo> cycleInfos = new LinkedList<>();
 
 	public void onVehicle() {
 		GpsTime onLocation = locationReceiver.getLocation();

--- a/monicar-emulator/src/main/java/org/emulator/device/application/port/CycleInfoEventPublisher.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/application/port/CycleInfoEventPublisher.java
@@ -1,0 +1,12 @@
+package org.emulator.device.application.port;
+
+import org.emulator.device.domain.CycleInfo;
+
+import java.util.List;
+
+/**
+ * 주기 정보 이벤트 발행 역할
+ */
+public interface CycleInfoEventPublisher {
+	void publishEvent(List<CycleInfo> cycleInfoList);
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/application/port/CycleInfoEventPublisher.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/application/port/CycleInfoEventPublisher.java
@@ -1,12 +1,10 @@
 package org.emulator.device.application.port;
 
-import org.emulator.device.domain.CycleInfo;
-
-import java.util.List;
+import org.emulator.device.infrastructure.external.command.CycleInfoListCommand;
 
 /**
  * 주기 정보 이벤트 발행 역할
  */
 public interface CycleInfoEventPublisher {
-	void publishEvent(List<CycleInfo> cycleInfoList);
+	void publishEvent(CycleInfoListCommand cycleInfoListCommand);
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/application/port/EmulatorRepository.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/application/port/EmulatorRepository.java
@@ -5,4 +5,5 @@ package org.emulator.device.application.port;
  */
 public interface EmulatorRepository {
 	int getTotalDistance();
+	int updateTotalDistance(int distance);
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/application/port/EmulatorRepository.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/application/port/EmulatorRepository.java
@@ -5,5 +5,6 @@ package org.emulator.device.application.port;
  */
 public interface EmulatorRepository {
 	int getTotalDistance();
-	int updateTotalDistance(int distance);
+
+	int plusTotalDistance(int distance);
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/application/port/LocationEventPublisher.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/application/port/LocationEventPublisher.java
@@ -1,7 +1,0 @@
-package org.emulator.device.application.port;
-
-/**
- * 위치 정보 이벤트 발행 역할
- */
-public interface LocationEventPublisher {
-}

--- a/monicar-emulator/src/main/java/org/emulator/device/application/port/LocationReceiver.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/application/port/LocationReceiver.java
@@ -1,14 +1,10 @@
 package org.emulator.device.application.port;
 
-import org.emulator.pipe.Gps;
-
-import java.util.List;
+import org.emulator.device.infrastructure.GpsTime;
 
 /**
  * 임의의 파일 or GPS 센서로부터 gps 정보를 받아온다.
  */
 public interface LocationReceiver {
-	Gps getLocation();
-
-	boolean readyToSend();
+	GpsTime getLocation();
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/domain/CycleInfo.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/domain/CycleInfo.java
@@ -3,14 +3,15 @@ package org.emulator.device.domain;
 import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import org.emulator.device.VehicleConstant;
 
-@AllArgsConstructor
+@Builder
 @Getter
 public class CycleInfo {
-	private LocalDateTime oTime;
+	private LocalDateTime intervalAt;
 	private GpsStatus gpsStatus;
 	private long latitude;
 	private long longitude;
@@ -20,7 +21,7 @@ public class CycleInfo {
 	private int battery;
 
 	public static CycleInfo create(
-		LocalDateTime oTime,
+		LocalDateTime intervalAt,
 		GpsStatus gpsStatus,
 		double latitude,
 		double longitude,
@@ -31,15 +32,16 @@ public class CycleInfo {
 	) {
 		long lat = (long)(latitude * VehicleConstant.MIL);
 		long lon = (long)(longitude * VehicleConstant.MIL);
-		return new CycleInfo(
-			oTime,
-			gpsStatus,
-			lat,
-			lon,
-			direction,
-			speed,
-			totalDistance,
-			battery
-		);
+
+		return CycleInfo.builder()
+			.intervalAt(intervalAt)
+			.gpsStatus(gpsStatus)
+			.latitude(lat)
+			.longitude(lon)
+			.direction(direction)
+			.speed(speed)
+			.totalDistance(totalDistance)
+			.battery(battery)
+			.build();
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/domain/CycleInfo.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/domain/CycleInfo.java
@@ -2,46 +2,42 @@ package org.emulator.device.domain;
 
 import java.time.LocalDateTime;
 
-import lombok.AllArgsConstructor;
+import org.emulator.device.VehicleConstant;
+import org.emulator.device.infrastructure.GpsTime;
+import org.emulator.device.infrastructure.external.command.vo.Direction;
+import org.emulator.device.infrastructure.external.command.vo.Geo;
+import org.emulator.device.infrastructure.external.command.vo.Speed;
+import org.emulator.device.infrastructure.external.command.vo.TotalDistance;
+
 import lombok.Builder;
 import lombok.Getter;
-
-import org.emulator.device.VehicleConstant;
 
 @Builder
 @Getter
 public class CycleInfo {
 	private LocalDateTime intervalAt;
 	private GpsStatus gpsStatus;
-	private long latitude;
-	private long longitude;
-	private int direction;
-	private int speed;
-	private int totalDistance;
+	private Geo geo;
+	private Direction direction;
+	private Speed speed;
+	private TotalDistance totalDistance;
 	private int battery;
 
 	public static CycleInfo create(
-		LocalDateTime intervalAt,
+		GpsTime gpsTime,
 		GpsStatus gpsStatus,
-		double latitude,
-		double longitude,
 		int direction,
 		int speed,
-		int totalDistance,
-		int battery
+		int totalDistance
 	) {
-		long lat = (long)(latitude * VehicleConstant.MIL);
-		long lon = (long)(longitude * VehicleConstant.MIL);
-
 		return CycleInfo.builder()
-			.intervalAt(intervalAt)
+			.intervalAt(gpsTime.intervalAt())
 			.gpsStatus(gpsStatus)
-			.latitude(lat)
-			.longitude(lon)
-			.direction(direction)
-			.speed(speed)
-			.totalDistance(totalDistance)
-			.battery(battery)
+			.geo(new Geo(gpsTime.location().lat(), gpsTime.location().lon()))
+			.direction(new Direction(direction))
+			.speed(new Speed(speed))
+			.totalDistance(new TotalDistance(totalDistance))
+			.battery(VehicleConstant.BATTERY)
 			.build();
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/domain/OnInfo.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/domain/OnInfo.java
@@ -2,17 +2,14 @@ package org.emulator.device.domain;
 
 import java.time.LocalDateTime;
 
-import lombok.AllArgsConstructor;
+import org.emulator.device.VehicleConstant;
+
 import lombok.Builder;
 import lombok.Getter;
 
-import org.emulator.device.VehicleConstant;
-
-@AllArgsConstructor
 @Getter
+@Builder
 public class OnInfo {
-	private static final int DEFAULT_ZERO = 0;
-
 	private LocalDateTime onTime;
 	private LocalDateTime offTime;
 	private GpsStatus gpsStatus;
@@ -32,14 +29,15 @@ public class OnInfo {
 		long lat = (long)(latitude * VehicleConstant.MIL);
 		long lon = (long)(longitude * VehicleConstant.MIL);
 
-		return new OnInfo(
-			onTime,
-			null,
-			gpsStatus,
-			lat,
-			lon,
-			DEFAULT_ZERO,
-			DEFAULT_ZERO,
-			totalDistance);
+		return OnInfo.builder()
+			.onTime(onTime)
+			.offTime(null)
+			.gpsStatus(gpsStatus)
+			.latitude(lat)
+			.longitude(lon)
+			.direction(0)
+			.speed(0)
+			.totalDistance(totalDistance)
+			.build();
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/domain/OnInfo.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/domain/OnInfo.java
@@ -2,7 +2,10 @@ package org.emulator.device.domain;
 
 import java.time.LocalDateTime;
 
-import org.emulator.device.VehicleConstant;
+import org.emulator.device.infrastructure.external.command.vo.Direction;
+import org.emulator.device.infrastructure.external.command.vo.Geo;
+import org.emulator.device.infrastructure.external.command.vo.Speed;
+import org.emulator.device.infrastructure.external.command.vo.TotalDistance;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -13,11 +16,10 @@ public class OnInfo {
 	private LocalDateTime onTime;
 	private LocalDateTime offTime;
 	private GpsStatus gpsStatus;
-	private long latitude;
-	private long longitude;
-	private int direction;
-	private int speed;
-	private int totalDistance;
+	private Geo geo;
+	private Direction direction;
+	private Speed speed;
+	private TotalDistance totalDistance;
 
 	public static OnInfo create(
 		LocalDateTime onTime,
@@ -26,18 +28,14 @@ public class OnInfo {
 		double longitude,
 		int totalDistance
 	) {
-		long lat = (long)(latitude * VehicleConstant.MIL);
-		long lon = (long)(longitude * VehicleConstant.MIL);
-
 		return OnInfo.builder()
 			.onTime(onTime)
 			.offTime(null)
 			.gpsStatus(gpsStatus)
-			.latitude(lat)
-			.longitude(lon)
-			.direction(0)
-			.speed(0)
-			.totalDistance(totalDistance)
+			.geo(new Geo(latitude, longitude))
+			.direction(new Direction())
+			.speed(new Speed())
+			.totalDistance(new TotalDistance(totalDistance))
 			.build();
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/domain/VehicleInfo.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/domain/VehicleInfo.java
@@ -1,8 +1,7 @@
 package org.emulator.device.domain;
 
+import java.util.ArrayList;
 import java.util.List;
-
-import org.emulator.device.VehicleConstant;
 
 /**
  * 에뮬레이터 전역 데이터를 관리하는 클래스
@@ -10,16 +9,26 @@ import org.emulator.device.VehicleConstant;
  * @field vehicleOffInfoList  시동 OFF 시간 이력 목록
  */
 public class VehicleInfo {
-	private String vehicleNumber;
-	private final String terminalId = VehicleConstant.TERMINAL_ID;
-	private final String manufacturerId = VehicleConstant.MANUFACTURER_ID;
-	private final String packetVersion = VehicleConstant.PACKET_VERSION;
-	private final String deviceId = VehicleConstant.DEVICE_ID;
+	private static final VehicleInfo INSTANCE = new VehicleInfo();
+
 	private List<OffInfo> vehicleOffInfoList;
-	private GeoPoint geoPoint;
 	private int totalDistance;
 
+	private VehicleInfo() {
+		vehicleOffInfoList = new ArrayList<>();
+		totalDistance = 0;
+	}
+
+	public static VehicleInfo getInstance() {
+		return INSTANCE;
+	}
+
 	public int getTotalDistance() {
+		return totalDistance;
+	}
+
+	public int updateTotalDistance(int distance) {
+		totalDistance += distance;
 		return totalDistance;
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/domain/VehicleInfo.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/domain/VehicleInfo.java
@@ -1,33 +1,22 @@
 package org.emulator.device.domain;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * 에뮬레이터 전역 데이터를 관리하는 클래스
  *
  * @field vehicleOffInfoList  시동 OFF 시간 이력 목록
  */
 public class VehicleInfo {
-	private static final VehicleInfo INSTANCE = new VehicleInfo();
-
-	private List<OffInfo> vehicleOffInfoList;
 	private int totalDistance;
 
-	private VehicleInfo() {
-		vehicleOffInfoList = new ArrayList<>();
+	public VehicleInfo() {
 		totalDistance = 0;
-	}
-
-	public static VehicleInfo getInstance() {
-		return INSTANCE;
 	}
 
 	public int getTotalDistance() {
 		return totalDistance;
 	}
 
-	public int updateTotalDistance(int distance) {
+	public int plusTotalDistance(int distance) {
 		totalDistance += distance;
 		return totalDistance;
 	}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/ApplicationCycleInfoEventListener.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/ApplicationCycleInfoEventListener.java
@@ -1,0 +1,27 @@
+package org.emulator.device.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+
+import org.emulator.device.application.port.CycleInfoEventPublisher;
+import org.emulator.device.domain.CycleInfo;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class ApplicationCycleInfoEventListener {
+	@Qualifier("kafkaCycleInfoEventPublisher")
+	private final CycleInfoEventPublisher publisher;
+
+	@EventListener
+	@Async
+	public void publishCycleInfoCommand(List<CycleInfo> cycleInfoList) {
+		// Make CycleInfoListCommand with cycleInfoList
+
+		// publish CycleInfoListCommand
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/ApplicationCycleInfoEventListener.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/ApplicationCycleInfoEventListener.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.emulator.device.application.port.CycleInfoEventPublisher;
 import org.emulator.device.domain.CycleInfo;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.emulator.device.infrastructure.external.command.CycleInfoListCommand;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -14,13 +14,12 @@ import java.util.List;
 @RequiredArgsConstructor
 @Component
 public class ApplicationCycleInfoEventListener {
-	@Qualifier("kafkaCycleInfoEventPublisher")
 	private final CycleInfoEventPublisher publisher;
 
 	@EventListener
 	@Async
 	public void publishCycleInfoCommand(List<CycleInfo> cycleInfoList) {
-		// Make CycleInfoListCommand with cycleInfoList
+		CycleInfoListCommand cycleInfoListCommand = CycleInfoListCommand.from(cycleInfoList);
 
 		// publish CycleInfoListCommand
 	}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/ApplicationCycleInfoEventPublisher.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/ApplicationCycleInfoEventPublisher.java
@@ -1,0 +1,23 @@
+package org.emulator.device.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+
+import org.emulator.device.application.port.CycleInfoEventPublisher;
+import org.emulator.device.domain.CycleInfo;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Qualifier("applicationCycleInfoEventPublisher")
+@RequiredArgsConstructor
+@Component
+public class ApplicationCycleInfoEventPublisher implements CycleInfoEventPublisher {
+	private final ApplicationEventPublisher eventPublisher;
+
+	@Override
+	public void publishEvent(List<CycleInfo> cycleInfoList) {
+		eventPublisher.publishEvent(cycleInfoList);
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/ApplicationCycleInfoEventPublisher.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/ApplicationCycleInfoEventPublisher.java
@@ -1,22 +1,18 @@
 package org.emulator.device.infrastructure;
 
-import lombok.RequiredArgsConstructor;
-
-import org.emulator.device.application.port.CycleInfoEventPublisher;
-import org.emulator.device.domain.CycleInfo;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Component;
-
 import java.util.List;
 
-@Qualifier("applicationCycleInfoEventPublisher")
+import org.emulator.device.domain.CycleInfo;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
 @RequiredArgsConstructor
-@Component
-public class ApplicationCycleInfoEventPublisher implements CycleInfoEventPublisher {
+@Service
+public class ApplicationCycleInfoEventPublisher {
 	private final ApplicationEventPublisher eventPublisher;
 
-	@Override
 	public void publishEvent(List<CycleInfo> cycleInfoList) {
 		eventPublisher.publishEvent(cycleInfoList);
 	}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsPipeQueueReceiver.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsPipeQueueReceiver.java
@@ -18,15 +18,11 @@ public class GpsPipeQueueReceiver implements LocationReceiver {
 
 	@Retryable(maxAttempts = 1, backoff = @Backoff(delay = 3000))
 	@Override
-	public Gps getLocation() {
-		return Objects.requireNonNull(
+	public GpsTime getLocation() {
+		Gps gps = Objects.requireNonNull(
 			gpsPipeQueue.poll(),
 			"No Gps data found. Check sensor"
 		);
-	}
-
-	@Override
-	public boolean readyToSend() {
-		return false;
+		return GpsTime.create(gps);
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsPipeQueueReceiver.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsPipeQueueReceiver.java
@@ -3,7 +3,7 @@ package org.emulator.device.infrastructure;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import org.emulator.device.application.port.LocationReceiver;
 import org.emulator.pipe.Gps;
@@ -11,7 +11,7 @@ import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Component
 public class GpsPipeQueueReceiver implements LocationReceiver {
 	private final ConcurrentLinkedQueue<Gps> gpsPipeQueue;

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTime.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTime.java
@@ -1,0 +1,14 @@
+package org.emulator.device.infrastructure;
+
+import org.emulator.pipe.Gps;
+
+import java.time.LocalDateTime;
+
+public record GpsTime(
+	Gps location,
+	LocalDateTime intervalAt
+) {
+	public static GpsTime create(Gps location) {
+		return new GpsTime(location, LocalDateTime.now());
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
@@ -1,5 +1,6 @@
 package org.emulator.device.infrastructure;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -11,11 +12,13 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.emulator.device.VehicleConstant;
+import org.emulator.device.application.port.CycleInfoEventPublisher;
 import org.emulator.device.application.port.LocationReceiver;
 import org.emulator.device.application.port.TransmissionTimeProvider;
 import org.emulator.device.domain.CycleInfo;
 import org.emulator.device.domain.GpsStatus;
-import org.emulator.pipe.Gps;
+import org.emulator.device.infrastructure.util.Calculator;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -27,8 +30,11 @@ public class GpsTracker implements SensorTracker {
 	private final LocationReceiver locationReceiver;
 	@Qualifier("emulatorTransmissionTimeProvider")
 	private final TransmissionTimeProvider timeProvider;
+	@Qualifier("applicationCycleInfoEventPublisher")
+	private final CycleInfoEventPublisher publisher;
 
 	private final Deque<CycleInfo> cycleInfos = new LinkedList<>();
+	private CycleInfo recentCycleInfo;
 
 	@Scheduled(initialDelay = 3000, fixedDelay = 1000)
 	@Override
@@ -36,27 +42,59 @@ public class GpsTracker implements SensorTracker {
 		int time = timeProvider.getTransmissionTime();
 
 		if (cycleInfos.size() > time) {
-			List<CycleInfo> sending = pollFromDeque(time);
-			// vehicleCommandSender.sendCycleCommand(sending);
+			List<CycleInfo> cycleInfoList = pollFromDeque(time);
+			publisher.publishEvent(cycleInfoList);
+
 			log.info("[Thread: {}] {}", Thread.currentThread().getName(), "sending!");
 		}
-		Gps location = locationReceiver.getLocation();
-		CycleInfo previousCycleInfo = cycleInfos.peekLast();
-		// 방향 연산
-		// 속도 연산
-		// 누적 거리 연산
+
+		GpsTime currentLocation = locationReceiver.getLocation();
+		// TODO: recentCycleInfo 가 null일 때 로직 개선
+		if (recentCycleInfo == null) {
+			CycleInfo currentCycleInfo = CycleInfo.create(
+				currentLocation.intervalAt(),
+				GpsStatus.A,
+				currentLocation.location().lat(),
+				currentLocation.location().lon(),
+				0,
+				0,
+				0,
+				VehicleConstant.BATTERY);
+			cycleInfos.add(currentCycleInfo);
+			recentCycleInfo = currentCycleInfo;
+			return;
+		}
+
+		int distance = Calculator.calculateDistance(
+			recentCycleInfo.getLatitude(),
+			recentCycleInfo.getLongitude(),
+			currentLocation.location().lat(),
+			currentLocation.location().lon()
+		);
+		int speed = Calculator.calculateSpeed(
+			distance,
+			Duration.between(recentCycleInfo.getIntervalAt(), currentLocation.intervalAt()).toMillis()
+		);
+		int direction = Calculator.calculateDirection(
+			recentCycleInfo.getLatitude(),
+			recentCycleInfo.getLongitude(),
+			currentLocation.location().lat(),
+			currentLocation.location().lon()
+		);
 		CycleInfo currentCycleInfo = CycleInfo.create(
-			LocalDateTime.now(),
+			currentLocation.intervalAt(),
 			GpsStatus.A,
-			location.lat(),
-			location.lon(),
-			270, // 방향 연산 값
-			100, // 속도 연산 값
-			10000, // 누적 거리 연산 값
-			100 // 배터리
+			currentLocation.location().lat(),
+			currentLocation.location().lon(),
+			distance,
+			speed,
+			direction,
+			VehicleConstant.BATTERY
 		);
 		cycleInfos.offerLast(currentCycleInfo);
-		log.info("[Thread: {}] {}", Thread.currentThread().getName(), "waiting..");
+		recentCycleInfo = currentCycleInfo;
+
+		log.info("[Thread: {}] {}", Thread.currentThread().getName(), "collecting data. . .");
 	}
 
 	public List<CycleInfo> pollFromDeque(int size) {

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
@@ -1,37 +1,31 @@
 package org.emulator.device.infrastructure;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Deque;
-
 import java.util.LinkedList;
-
 import java.util.List;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import org.emulator.device.VehicleConstant;
-import org.emulator.device.application.port.CycleInfoEventPublisher;
+import org.emulator.device.application.port.EmulatorRepository;
 import org.emulator.device.application.port.LocationReceiver;
 import org.emulator.device.application.port.TransmissionTimeProvider;
 import org.emulator.device.domain.CycleInfo;
 import org.emulator.device.domain.GpsStatus;
 import org.emulator.device.infrastructure.util.Calculator;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class GpsTracker implements SensorTracker {
 	private final LocationReceiver locationReceiver;
-	@Qualifier("emulatorTransmissionTimeProvider")
+	private final EmulatorRepository emulatorRepository;
 	private final TransmissionTimeProvider timeProvider;
-	@Qualifier("applicationCycleInfoEventPublisher")
-	private final CycleInfoEventPublisher publisher;
+	private final ApplicationCycleInfoEventPublisher applicationEventPublisher;
 
 	private final Deque<CycleInfo> cycleInfos = new LinkedList<>();
 	private CycleInfo recentCycleInfo;
@@ -43,65 +37,72 @@ public class GpsTracker implements SensorTracker {
 
 		if (cycleInfos.size() > time) {
 			List<CycleInfo> cycleInfoList = pollFromDeque(time);
-			publisher.publishEvent(cycleInfoList);
+			applicationEventPublisher.publishEvent(cycleInfoList);
 
 			log.info("[Thread: {}] {}", Thread.currentThread().getName(), "sending!");
 		}
 
 		GpsTime currentLocation = locationReceiver.getLocation();
-		// TODO: recentCycleInfo 가 null일 때 로직 개선
 		if (recentCycleInfo == null) {
 			CycleInfo currentCycleInfo = CycleInfo.create(
-				currentLocation.intervalAt(),
+				currentLocation,
 				GpsStatus.A,
-				currentLocation.location().lat(),
-				currentLocation.location().lon(),
 				0,
 				0,
-				0,
-				VehicleConstant.BATTERY);
-			cycleInfos.add(currentCycleInfo);
+				0
+			);
+			cycleInfos.offerLast(currentCycleInfo);
 			recentCycleInfo = currentCycleInfo;
 			return;
 		}
 
-		int distance = Calculator.calculateDistance(
-			recentCycleInfo.getLatitude(),
-			recentCycleInfo.getLongitude(),
-			currentLocation.location().lat(),
-			currentLocation.location().lon()
-		);
-		int speed = Calculator.calculateSpeed(
-			distance,
-			Duration.between(recentCycleInfo.getIntervalAt(), currentLocation.intervalAt()).toMillis()
-		);
-		int direction = Calculator.calculateDirection(
-			recentCycleInfo.getLatitude(),
-			recentCycleInfo.getLongitude(),
-			currentLocation.location().lat(),
-			currentLocation.location().lon()
-		);
+		int direction = getDirection(recentCycleInfo, currentLocation);
+		int distance = getDistance(recentCycleInfo, currentLocation);
+		int speed = getSpeed(distance, recentCycleInfo, currentLocation);
+
 		CycleInfo currentCycleInfo = CycleInfo.create(
-			currentLocation.intervalAt(),
+			currentLocation,
 			GpsStatus.A,
-			currentLocation.location().lat(),
-			currentLocation.location().lon(),
-			distance,
-			speed,
 			direction,
-			VehicleConstant.BATTERY
+			speed,
+			distance
 		);
 		cycleInfos.offerLast(currentCycleInfo);
 		recentCycleInfo = currentCycleInfo;
 
+		emulatorRepository.updateTotalDistance(distance);
+
 		log.info("[Thread: {}] {}", Thread.currentThread().getName(), "collecting data. . .");
 	}
 
-	public List<CycleInfo> pollFromDeque(int size) {
+	private List<CycleInfo> pollFromDeque(int size) {
 		List<CycleInfo> result = new ArrayList<>();
 		while (!cycleInfos.isEmpty() && result.size() < size) {
 			result.add(cycleInfos.pollFirst());
 		}
 		return result;
+	}
+
+	private int getDistance(CycleInfo preInfo, GpsTime curInfo) {
+		return Calculator.calculateDistance(
+			preInfo.getGeo().getLatitude(),
+			preInfo.getGeo().getLongitude(),
+			curInfo.location().lat(),
+			curInfo.location().lon()
+		);
+	}
+
+	private int getSpeed(int distance, CycleInfo preInfo, GpsTime curInfo) {
+		Duration duration = Duration.between(preInfo.getIntervalAt(), curInfo.intervalAt());
+		return Calculator.calculateSpeed(distance, duration.toMillis());
+	}
+
+	private int getDirection(CycleInfo preInfo, GpsTime curInfo) {
+		return Calculator.calculateDirection(
+			preInfo.getGeo().getLatitude(),
+			preInfo.getGeo().getLongitude(),
+			curInfo.location().lat(),
+			curInfo.location().lon()
+		);
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
@@ -6,11 +6,13 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.emulator.device.application.port.CycleInfoEventPublisher;
 import org.emulator.device.application.port.EmulatorRepository;
 import org.emulator.device.application.port.LocationReceiver;
 import org.emulator.device.application.port.TransmissionTimeProvider;
 import org.emulator.device.domain.CycleInfo;
 import org.emulator.device.domain.GpsStatus;
+import org.emulator.device.infrastructure.external.command.CycleInfoListCommand;
 import org.emulator.device.infrastructure.util.Calculator;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -26,6 +28,8 @@ public class GpsTracker implements SensorTracker {
 	private final EmulatorRepository emulatorRepository;
 	private final TransmissionTimeProvider timeProvider;
 	private final ApplicationCycleInfoEventPublisher applicationEventPublisher;
+	private final CycleInfoEventPublisher cycleInfoEventPublisher;
+
 
 	private final Deque<CycleInfo> cycleInfos = new LinkedList<>();
 	private CycleInfo recentCycleInfo;
@@ -37,9 +41,9 @@ public class GpsTracker implements SensorTracker {
 
 		if (cycleInfos.size() > time) {
 			List<CycleInfo> cycleInfoList = pollFromDeque(time);
-			applicationEventPublisher.publishEvent(cycleInfoList);
 
-			log.info("[Thread: {}] {}", Thread.currentThread().getName(), "sending!");
+			CycleInfoListCommand message = CycleInfoListCommand.from(cycleInfoList);
+			cycleInfoEventPublisher.publishEvent(message);
 		}
 
 		GpsTime currentLocation = locationReceiver.getLocation();

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
@@ -53,7 +53,7 @@ public class GpsTracker implements SensorTracker {
 				GpsStatus.A,
 				0,
 				0,
-				totalDistance
+				0
 			);
 			cycleInfos.offerLast(currentCycleInfo);
 			recentCycleInfo = currentCycleInfo;

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
@@ -36,7 +36,6 @@ public class GpsTracker implements SensorTracker {
 	@Override
 	public void track() {
 		int time = timeProvider.getTransmissionTime();
-		int totalDistance = emulatorRepository.getTotalDistance();
 
 		if (cycleInfos.size() > time) {
 			List<CycleInfo> cycleInfoList = pollFromDeque(time);
@@ -69,7 +68,7 @@ public class GpsTracker implements SensorTracker {
 			GpsStatus.A,
 			direction,
 			speed,
-			totalDistance + distance
+			emulatorRepository.getTotalDistance() + distance
 		);
 		cycleInfos.offerLast(currentCycleInfo);
 		recentCycleInfo = currentCycleInfo;

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/GpsTracker.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import org.emulator.device.application.port.CycleInfoEventPublisher;
 import org.emulator.device.application.port.EmulatorRepository;
@@ -81,7 +82,10 @@ public class GpsTracker implements SensorTracker {
 	private List<CycleInfo> pollFromDeque(int size) {
 		List<CycleInfo> result = new ArrayList<>();
 		while (!cycleInfos.isEmpty() && result.size() < size) {
-			result.add(cycleInfos.pollFirst());
+			CycleInfo cycleInfo = cycleInfos.pollFirst();
+			if (Objects.nonNull(cycleInfo)) {
+				result.add(cycleInfo);
+			}
 		}
 		return result;
 	}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/RestClientService.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/RestClientService.java
@@ -3,15 +3,15 @@ package org.emulator.device.infrastructure.external;
 import java.io.InputStream;
 import java.util.Map;
 
+import lombok.RequiredArgsConstructor;
+
 import org.common.dto.CommonResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import lombok.AllArgsConstructor;
-
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Service
 public class RestClientService {
 	private final Map<UrlPathEnum, RestClient> restClients;

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/RestClientVehicleCommandSender.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/RestClientVehicleCommandSender.java
@@ -3,6 +3,8 @@ package org.emulator.device.infrastructure.external;
 import java.util.List;
 import java.util.Map;
 
+import lombok.RequiredArgsConstructor;
+
 import org.common.dto.CommonResponse;
 import org.emulator.device.application.port.VehicleCommandSender;
 import org.emulator.device.domain.CycleInfo;
@@ -13,9 +15,8 @@ import org.emulator.device.infrastructure.external.command.OnCommand;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
-import lombok.AllArgsConstructor;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Component
 public class RestClientVehicleCommandSender implements VehicleCommandSender {
 	private final RestClientService restClientService;
@@ -24,7 +25,7 @@ public class RestClientVehicleCommandSender implements VehicleCommandSender {
 		RestClient restClient = restClientService.getRestClient(UrlPathEnum.CONTROL_CENTER);
 
 		// body: onInfo - onCommand 매핑
-		OnCommand onCommand = OnCommand.of(onInfo);
+		OnCommand onCommand = OnCommand.from(onInfo);
 		Map<String, String> headers = HeaderUtils.additionalHeaders(HeaderName.TIMESTAMP, HeaderName.TUID);
 
 		return restClientService.post(

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/CycleInfoCommand.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/CycleInfoCommand.java
@@ -1,0 +1,28 @@
+package org.emulator.device.infrastructure.external.command;
+
+import org.emulator.device.domain.GpsStatus;
+
+/**
+ * 주기 정보 데이터 리스트 레코드
+ *
+ * @param intervalAt  발생 시간 (초) - 시간 값을 초 단위로 나타냄 (형식: 'ss')
+ * @param gcd  GPS 상태 - GPS 수신 상태 ('A': 정상, 'V': 비정상, '0': 미장착)
+ * @param lat  GPS 위도 - 위도 * 1000000 (소수점 6자리, 단위: 위도 값)
+ * @param lon  GPS 경도 - 경도 * 1000000 (소수점 6자리, 단위: 경도 값)
+ * @param ang  방향 - 차량의 현재 진행 방향 (범위: 0 ~ 365)
+ * @param spd  속도 - 차량의 현재 속도 (범위: 0 ~ 255, 단위: km/h)
+ * @param sum  누적 주행 거리 - 차량의 현재 총 주행 거리 (범위: 0 ~ 9999999, 단위: m)
+ * @param bat  배터리 전압 - 배터리 전압 * 10 (범위: 0 ~ 9999, 단위: V)
+ */
+public record CycleInfoCommand(
+	String intervalAt,
+	GpsStatus gcd,
+	long lat,
+	long lon,
+	int ang,
+	int spd,
+	int sum,
+	int bat
+) {
+
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/CycleInfoCommand.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/CycleInfoCommand.java
@@ -1,5 +1,12 @@
 package org.emulator.device.infrastructure.external.command;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+import org.emulator.device.domain.CycleInfo;
 import org.emulator.device.domain.GpsStatus;
 
 /**
@@ -14,8 +21,9 @@ import org.emulator.device.domain.GpsStatus;
  * @param sum  누적 주행 거리 - 차량의 현재 총 주행 거리 (범위: 0 ~ 9999999, 단위: m)
  * @param bat  배터리 전압 - 배터리 전압 * 10 (범위: 0 ~ 9999, 단위: V)
  */
+@Builder
 public record CycleInfoCommand(
-	String intervalAt,
+	@JsonFormat(pattern = "yyyyMMddHHmmss") LocalDateTime intervalAt,
 	GpsStatus gcd,
 	long lat,
 	long lon,
@@ -24,5 +32,15 @@ public record CycleInfoCommand(
 	int sum,
 	int bat
 ) {
-
+	public static CycleInfoCommand from(CycleInfo cycleInfo) {
+		return CycleInfoCommand.builder()
+			.intervalAt(cycleInfo.getIntervalAt())
+			.gcd(cycleInfo.getGpsStatus())
+			.lat(cycleInfo.getGeo().getLatitude())
+			.lon(cycleInfo.getGeo().getLongitude())
+			.ang(cycleInfo.getDirection().getValue())
+			.spd(cycleInfo.getSpeed().getValue())
+			.sum(cycleInfo.getTotalDistance().getValue())
+			.build();
+	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/CycleInfoListCommand.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/CycleInfoListCommand.java
@@ -1,0 +1,13 @@
+package org.emulator.device.infrastructure.external.command;
+
+import java.util.List;
+
+public record CycleInfoListCommand(
+	String mdn,
+	String tid,
+	String mid,
+	String pv,
+	String did,
+	String cCnt,
+	List<CycleInfoCommand> cList
+) {}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/CycleInfoListCommand.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/CycleInfoListCommand.java
@@ -1,13 +1,40 @@
 package org.emulator.device.infrastructure.external.command;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import java.util.stream.Collectors;
+
+import lombok.Builder;
+
+import org.emulator.device.domain.CycleInfo;
+import org.emulator.device.infrastructure.external.command.vo.FixedVehicleInfo;
+
+@Builder
 public record CycleInfoListCommand(
-	String mdn,
+	long mdn,
 	String tid,
-	String mid,
-	String pv,
-	String did,
-	String cCnt,
+	long mid,
+	int pv,
+	long did,
+	int cCnt,
 	List<CycleInfoCommand> cList
-) {}
+) {
+	public static CycleInfoListCommand from(List<CycleInfo> cycleInfoList) {
+		FixedVehicleInfo fixedInfo = FixedVehicleInfo.getInstance();
+		List<CycleInfoCommand> cycleList = cycleInfoList.stream()
+			.map(CycleInfoCommand::from)
+			.collect(Collectors.toCollection(ArrayList::new)
+			);
+
+		return CycleInfoListCommand.builder()
+			.mdn(fixedInfo.getMdn())
+			.tid(fixedInfo.getTid())
+			.mid(fixedInfo.getMid())
+			.pv(fixedInfo.getPv())
+			.did(fixedInfo.getDid())
+			.cCnt(cycleList.size())
+			.cList(cycleList)
+			.build();
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/CycleInfoListCommand.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/CycleInfoListCommand.java
@@ -3,6 +3,7 @@ package org.emulator.device.infrastructure.external.command;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import lombok.Builder;
@@ -23,8 +24,9 @@ public record CycleInfoListCommand(
 	public static CycleInfoListCommand from(List<CycleInfo> cycleInfoList) {
 		FixedVehicleInfo fixedInfo = FixedVehicleInfo.getInstance();
 		List<CycleInfoCommand> cycleList = cycleInfoList.stream()
-			.map(CycleInfoCommand::from)
-			.collect(Collectors.toCollection(ArrayList::new)
+				.filter(Objects::nonNull)
+				.map(CycleInfoCommand::from)
+				.collect(Collectors.toCollection(ArrayList::new)
 			);
 
 		return CycleInfoListCommand.builder()

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/OnCommand.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/OnCommand.java
@@ -45,16 +45,16 @@ public record OnCommand(
 	public static final int TOTAL_DISTANCE_MAX = 9999999;
 
 	public static OnCommand of(OnInfo onInfo) {
-		DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
-		String onTime = onInfo.getOnTime().format(DATE_TIME_FORMATTER);
+		String onTime = onInfo.getOnTime().format(dateTimeFormatter);
 		String offTime = "";
 		String lat = String.valueOf(onInfo.getLatitude());
 		String lon = String.valueOf(onInfo.getLongitude());
-		String ang = String.valueOf(Math.min(Math.max(onInfo.getDirection(), DIRECTION_MIN), DIRECTION_MAX));
-		String spd = String.valueOf(Math.min(Math.max(onInfo.getSpeed(), SPEED_MIN), SPEED_MAX));
+		String ang = String.valueOf(Math.clamp(onInfo.getDirection(), DIRECTION_MIN, DIRECTION_MAX));
+		String spd = String.valueOf(Math.clamp(onInfo.getSpeed(), SPEED_MIN, SPEED_MAX));
 		String sum = String.valueOf(
-			Math.min(Math.max(onInfo.getTotalDistance(), TOTAL_DISTANCE_MIN), TOTAL_DISTANCE_MAX));
+			Math.clamp(onInfo.getTotalDistance(), TOTAL_DISTANCE_MIN, TOTAL_DISTANCE_MAX));
 
 		return new OnCommand(
 			VehicleConstant.VEHICLE_NUM,

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Direction.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Direction.java
@@ -1,0 +1,21 @@
+package org.emulator.device.infrastructure.external.command.vo;
+
+import lombok.Getter;
+
+@Getter
+public class Direction {
+	public static final int DIRECTION_MIN = 0;
+	public static final int DIRECTION_MAX = 365;
+
+	private final int value;
+
+	public Direction() {
+		this.value = 0;
+	}
+
+	public Direction(int value) {
+		if (value < DIRECTION_MIN || value > DIRECTION_MAX)
+			throw new IllegalArgumentException("direction out of range");
+		this.value = value;
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Direction.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Direction.java
@@ -14,8 +14,6 @@ public class Direction {
 	}
 
 	public Direction(int value) {
-		if (value < DIRECTION_MIN || value > DIRECTION_MAX)
-			throw new IllegalArgumentException("direction out of range");
-		this.value = value;
+		this.value = Math.clamp(value, DIRECTION_MIN, DIRECTION_MAX);
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/FixedVehicleInfo.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/FixedVehicleInfo.java
@@ -1,0 +1,40 @@
+package org.emulator.device.infrastructure.external.command.vo;
+
+import lombok.Getter;
+
+import org.emulator.device.VehicleConstant;
+
+/**
+ * 차량의 기본 데이터를 담는 VO
+ *
+ * @field mdn     차량 번호 - 차량을 식별하는 고유 번호
+ * @field num	  차량 번호 - 번호판 번호
+ * @field tid     터미널 아이디 - 터미널 장치의 고유 식별자
+ * @field mid     제조사 아이디 - 제조사를 구분하는 식별자
+ * @field pv      패킷 버전 - 데이터 패킷의 버전 정보
+ * @field did     디바이스 아이디 - 설치된 디바이스의 고유 식별자
+ */
+@Getter
+public class FixedVehicleInfo {
+	private static final FixedVehicleInfo INSTANCE = new FixedVehicleInfo();
+
+	private final long mdn;
+	private final String num;
+	private final String tid;
+	private final long mid;
+	private final int pv;
+	private final long did;
+
+	private FixedVehicleInfo() {
+		this.mdn = VehicleConstant.VEHICLE_PRIMARY_KEY;
+		this.num = VehicleConstant.VEHICLE_NUMBER;
+		this.tid = VehicleConstant.TERMINAL_ID;
+		this.mid = VehicleConstant.MANUFACTURER_ID;
+		this.pv = VehicleConstant.PACKET_VERSION;
+		this.did = VehicleConstant.DEVICE_ID;
+	}
+
+	public static FixedVehicleInfo getInstance() {
+		return INSTANCE;
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Geo.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Geo.java
@@ -1,0 +1,30 @@
+package org.emulator.device.infrastructure.external.command.vo;
+
+import lombok.Getter;
+
+import org.emulator.device.VehicleConstant;
+
+@Getter
+public class Geo {
+	private static final double LATITUDE_MIN = -80.000000;
+	private static final double LATITUDE_MAX = 80.000000;
+	private static final double LONGITUDE_MIN = -180.000000;
+	private static final double LONGITUDE_MAX = 180.000000;
+
+	private final long latitude;
+	private final long longitude;
+
+	public Geo() {
+		this.latitude = 0L;
+		this.longitude = 0L;
+	}
+
+	public Geo(double latitude, double longitude) {
+		if (latitude < LATITUDE_MIN || latitude > LATITUDE_MAX)
+			throw new IllegalArgumentException("latitude out of range");
+		if (longitude < LONGITUDE_MIN || longitude > LONGITUDE_MAX)
+			throw new IllegalArgumentException("longitude out of range");
+		this.latitude =(long)(latitude * VehicleConstant.MIL);
+		this.longitude = (long)(longitude * VehicleConstant.MIL);
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Geo.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Geo.java
@@ -6,10 +6,10 @@ import org.emulator.device.VehicleConstant;
 
 @Getter
 public class Geo {
-	private static final double LATITUDE_MIN = -80.000000;
-	private static final double LATITUDE_MAX = 80.000000;
-	private static final double LONGITUDE_MIN = -180.000000;
-	private static final double LONGITUDE_MAX = 180.000000;
+	private static final long LATITUDE_MIN = -80000000L;
+	private static final long LATITUDE_MAX = 80000000L;
+	private static final long LONGITUDE_MIN = -180000000L;
+	private static final long LONGITUDE_MAX = 180000000L;
 
 	private final long latitude;
 	private final long longitude;
@@ -20,11 +20,7 @@ public class Geo {
 	}
 
 	public Geo(double latitude, double longitude) {
-		if (latitude < LATITUDE_MIN || latitude > LATITUDE_MAX)
-			throw new IllegalArgumentException("latitude out of range");
-		if (longitude < LONGITUDE_MIN || longitude > LONGITUDE_MAX)
-			throw new IllegalArgumentException("longitude out of range");
-		this.latitude =(long)(latitude * VehicleConstant.MIL);
-		this.longitude = (long)(longitude * VehicleConstant.MIL);
+		this.latitude = Math.clamp((long)(latitude * VehicleConstant.MIL), LATITUDE_MIN, LATITUDE_MAX);
+		this.longitude = Math.clamp((long)(longitude * VehicleConstant.MIL), LONGITUDE_MIN, LONGITUDE_MAX);
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Speed.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Speed.java
@@ -1,0 +1,21 @@
+package org.emulator.device.infrastructure.external.command.vo;
+
+import lombok.Getter;
+
+@Getter
+public class Speed {
+	private static final int SPEED_MIN = 0;
+	private static final int SPEED_MAX = 255;
+
+	private final int value;
+
+	public Speed() {
+		this.value = 0;
+	}
+
+	public Speed(int value) {
+		if (value < SPEED_MIN || value > SPEED_MAX)
+			throw new IllegalArgumentException("speed out of range");
+		this.value = value;
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Speed.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/Speed.java
@@ -14,8 +14,6 @@ public class Speed {
 	}
 
 	public Speed(int value) {
-		if (value < SPEED_MIN || value > SPEED_MAX)
-			throw new IllegalArgumentException("speed out of range");
-		this.value = value;
+		this.value = Math.clamp(value, SPEED_MIN, SPEED_MAX);
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/TotalDistance.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/TotalDistance.java
@@ -1,0 +1,21 @@
+package org.emulator.device.infrastructure.external.command.vo;
+
+import lombok.Getter;
+
+@Getter
+public class TotalDistance {
+	public static final int TOTAL_DISTANCE_MIN = 0;
+	public static final int TOTAL_DISTANCE_MAX = 9999999;
+
+	private final int value;
+
+	public TotalDistance() {
+		this.value = 0;
+	}
+
+	public TotalDistance(int value) {
+		if (value < TOTAL_DISTANCE_MIN || value > TOTAL_DISTANCE_MAX)
+			throw new IllegalArgumentException("totalDistance out of range");
+		this.value = value;
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/TotalDistance.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/external/command/vo/TotalDistance.java
@@ -14,8 +14,6 @@ public class TotalDistance {
 	}
 
 	public TotalDistance(int value) {
-		if (value < TOTAL_DISTANCE_MIN || value > TOTAL_DISTANCE_MAX)
-			throw new IllegalArgumentException("totalDistance out of range");
-		this.value = value;
+		this.value = Math.clamp(value, TOTAL_DISTANCE_MIN, TOTAL_DISTANCE_MAX);
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/messaging/KafkaCycleInfoEventPublisher.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/messaging/KafkaCycleInfoEventPublisher.java
@@ -1,0 +1,17 @@
+package org.emulator.device.infrastructure.messaging;
+
+import org.emulator.device.application.port.CycleInfoEventPublisher;
+import org.emulator.device.domain.CycleInfo;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Qualifier("kafkaCycleInfoEventPublisher")
+@Component
+public class KafkaCycleInfoEventPublisher implements CycleInfoEventPublisher {
+	@Override
+	public void publishEvent(List<CycleInfo> cycleInfoList) {
+		// TODO: kafka 이벤트 발행
+	}
+}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/messaging/KafkaCycleInfoEventPublisher.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/messaging/KafkaCycleInfoEventPublisher.java
@@ -1,17 +1,13 @@
 package org.emulator.device.infrastructure.messaging;
 
 import org.emulator.device.application.port.CycleInfoEventPublisher;
-import org.emulator.device.domain.CycleInfo;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.emulator.device.infrastructure.external.command.CycleInfoListCommand;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
-@Qualifier("kafkaCycleInfoEventPublisher")
 @Component
 public class KafkaCycleInfoEventPublisher implements CycleInfoEventPublisher {
 	@Override
-	public void publishEvent(List<CycleInfo> cycleInfoList) {
+	public void publishEvent(CycleInfoListCommand cycleInfoListCommand) {
 		// TODO: kafka 이벤트 발행
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/messaging/KafkaCycleInfoEventPublisher.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/messaging/KafkaCycleInfoEventPublisher.java
@@ -1,13 +1,25 @@
 package org.emulator.device.infrastructure.messaging;
 
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+
 import org.emulator.device.application.port.CycleInfoEventPublisher;
 import org.emulator.device.infrastructure.external.command.CycleInfoListCommand;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+@Slf4j
+@RequiredArgsConstructor
 @Component
 public class KafkaCycleInfoEventPublisher implements CycleInfoEventPublisher {
+	private final KafkaTemplate<String, CycleInfoListCommand> kafkaTemplate;
+
 	@Override
-	public void publishEvent(CycleInfoListCommand cycleInfoListCommand) {
-		// TODO: kafka 이벤트 발행
+	@Async
+	public void publishEvent(CycleInfoListCommand message) {
+		log.info("[Thread: {}] {}", Thread.currentThread().getName(), "publish message. . .");
+		kafkaTemplate.send("cycleInfo-json-topic", String.valueOf(message.mdn()), message);
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/messaging/KafkaLocationEventPublisher.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/messaging/KafkaLocationEventPublisher.java
@@ -1,8 +1,0 @@
-package org.emulator.device.infrastructure.messaging;
-
-import org.emulator.device.application.port.LocationEventPublisher;
-import org.springframework.stereotype.Component;
-
-@Component
-public class KafkaLocationEventPublisher implements LocationEventPublisher {
-}

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/repository/InMemoryEmulatorRepository.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/repository/InMemoryEmulatorRepository.java
@@ -6,10 +6,15 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public class InMemoryEmulatorRepository implements EmulatorRepository {
-	private VehicleInfo vehicleInfo = new VehicleInfo();
+	private VehicleInfo vehicleInfo = VehicleInfo.getInstance();
 
 	@Override
 	public int getTotalDistance() {
 		return vehicleInfo.getTotalDistance();
+	}
+
+	@Override
+	public int updateTotalDistance(int distance) {
+		return vehicleInfo.updateTotalDistance(distance);
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/repository/InMemoryEmulatorRepository.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/repository/InMemoryEmulatorRepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public class InMemoryEmulatorRepository implements EmulatorRepository {
-	private VehicleInfo vehicleInfo = VehicleInfo.getInstance();
+	private VehicleInfo vehicleInfo = new VehicleInfo();
 
 	@Override
 	public int getTotalDistance() {
@@ -14,7 +14,7 @@ public class InMemoryEmulatorRepository implements EmulatorRepository {
 	}
 
 	@Override
-	public int updateTotalDistance(int distance) {
-		return vehicleInfo.updateTotalDistance(distance);
+	public int plusTotalDistance(int distance) {
+		return vehicleInfo.plusTotalDistance(distance);
 	}
 }

--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/util/Calculator.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/util/Calculator.java
@@ -1,0 +1,73 @@
+package org.emulator.device.infrastructure.util;
+
+public class Calculator {
+	private static final double EARTH_RADIUS = 6371000;
+	private static final int MAX_DISTANCE = 9_999_999;
+	private static final int MAX_DIRECTION = 365;
+	private static final int MAX_SPEED = 255;
+	private static final int MIN_SPEED = 0;
+
+	/**
+	 * Haversine 공식 (지구 표면상 두 점 사이의 최단 거리를 구하는 공식) 을 사용하여 두 지점 간의 거리를 계산
+	 *
+	 * @return 이동 거리 (미터, 0 ~ 9,999,999)
+	 */
+	public static int calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+		double dLat = Math.toRadians(lat2 - lat1);
+		double dLon = Math.toRadians(lon2 - lon1);
+
+		double radLat1 = Math.toRadians(lat1);
+		double radLat2 = Math.toRadians(lat2);
+
+		double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+			+ Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(radLat1) * Math.cos(radLat2);
+		double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+		double distance = EARTH_RADIUS * c;
+		return (int) Math.min(distance, MAX_DISTANCE);
+	}
+
+	/**
+	 * 방위각(북쪽을 기준으로 시계 방향으로 측정된 각도) 계산 공식을 사용하여 두 지점 간의 방향을 계산
+	 *
+	 * @return 방위각 (도, 0 ~ 365)
+	 */
+	public static int calculateDirection(double lat1, double lon1, double lat2, double lon2) {
+		double radLat1 = Math.toRadians(lat1);
+		double radLat2 = Math.toRadians(lat2);
+		double deltaLon = Math.toRadians(lon2 - lon1);
+
+		double y = Math.sin(deltaLon) * Math.cos(radLat2);
+		double x = Math.cos(radLat1) * Math.sin(radLat2) -
+			Math.sin(radLat1) * Math.cos(radLat2) * Math.cos(deltaLon);
+		double bearing = Math.toDegrees(Math.atan2(y, x));
+		bearing = (bearing + 360) % 360;
+
+		return (int) Math.min(bearing, MAX_DIRECTION);
+	}
+
+	/**
+	 * 이동 거리와 시간 차이를 기반으로 속도를 계산하고, 이를 0 ~ 255 범위로 스케일링합니다.
+	 *
+	 * @param distance 이동 거리 (미터)
+	 * @param timeMillis    시간 차이 (밀리 초)
+	 * @return 스케일된 속도 (0 ~ 255)
+	 */
+	public static int calculateSpeed(int distance, long timeMillis) {
+		if (timeMillis <= 0) {
+			return 0;
+		}
+		double timeSeconds = timeMillis / 1000.0;
+		double speedMps = distance / timeSeconds; // 초당 속도 (m/s)
+
+		// 스케일링을 위한 최대 예상 속도 (자동차의 최고 속도인 약 70 m/s -> 252 km/h)
+		double expectedMaxSpeed = 70.0;
+		int speed = (int) ((speedMps / expectedMaxSpeed) * MAX_SPEED);
+		speed = Math.min(speed, MAX_SPEED);
+		return Math.max(speed, MIN_SPEED);
+	}
+
+	private Calculator() {
+		throw new IllegalAccessError("Utility class");
+	}
+}

--- a/monicar-emulator/src/main/resources/application.yml
+++ b/monicar-emulator/src/main/resources/application.yml
@@ -5,6 +5,19 @@ spring:
   application:
     name: monicar-emulator
 
+  kafka:
+    bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      auto-offset-reset: latest
+    listener:
+      concurrency: 1
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: 1
+
 logging:
   level:
     org:

--- a/monicar-emulator/src/test/java/org/emulator/device/infrastructure/external/RestClientServiceTest.java
+++ b/monicar-emulator/src/test/java/org/emulator/device/infrastructure/external/RestClientServiceTest.java
@@ -25,6 +25,7 @@ import org.springframework.web.client.RestClient;
 
 import java.time.LocalDateTime;
 
+@DisplayName("RestClientService 요청 테스트")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = RestClientFactory.class)
 class RestClientServiceTest {
@@ -34,10 +35,10 @@ class RestClientServiceTest {
 
 	private ClientAndServer mockServer;
 
-	private ObjectMapper mapper = new ObjectMapper();
+	private final ObjectMapper mapper = new ObjectMapper();
 
 	@BeforeEach
-	public void setUP() {
+	public void setUp() {
 		mockServer = ClientAndServer.startClientAndServer(8081);
 	}
 
@@ -46,7 +47,7 @@ class RestClientServiceTest {
 		mockServer.stop();
 	}
 
-	@DisplayName("시동 on 요청 성공 테스트입니다")
+	@DisplayName("post 성공 테스트")
 	@Test
 	void postKeyOn() throws Exception {
 		//given

--- a/monicar-emulator/src/test/java/org/emulator/device/infrastructure/external/RestClientServiceTest.java
+++ b/monicar-emulator/src/test/java/org/emulator/device/infrastructure/external/RestClientServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockserver.model.HttpResponse.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.common.dto.CommonResponse;
+import org.emulator.config.JacksonConfig;
 import org.emulator.device.domain.GpsStatus;
 import org.emulator.device.domain.OnInfo;
 import org.emulator.device.infrastructure.external.command.OnCommand;
@@ -27,15 +28,16 @@ import java.time.LocalDateTime;
 
 @DisplayName("RestClientService 요청 테스트")
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = RestClientFactory.class)
+@ContextConfiguration(classes = {RestClientFactory.class, JacksonConfig.class})
 class RestClientServiceTest {
 
 	@Autowired
 	private RestClientService restClientService;
+	@Autowired
+	private ObjectMapper mapper;
 
 	private ClientAndServer mockServer;
 
-	private final ObjectMapper mapper = new ObjectMapper();
 
 	@BeforeEach
 	public void setUp() {
@@ -52,7 +54,7 @@ class RestClientServiceTest {
 	void postKeyOn() throws Exception {
 		//given
 		RestClient restClient = restClientService.getRestClient(UrlPathEnum.CONTROL_CENTER);
-		OnCommand command = OnCommand.of(OnInfo.create(LocalDateTime.now(), GpsStatus.A, 20.111111, 30.111111, 5000));
+		OnCommand command = OnCommand.from(OnInfo.create(LocalDateTime.now(), GpsStatus.A, 20.111111, 30.111111, 5000));
 		CommonResponse expected = new CommonResponse("000", "Success", "01234567890");
 
 		mockServer.when(


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

일단 카프카 이벤트 퍼블리싱 아주 간단하게 구현했습니다.
docker-compose.yml 파일에 이미 정의된 카프카 컨테이너들(브로커들) 기반으로 돌아갑니다 


<img width="738" alt="Screenshot 2025-01-06 at 8 29 23 PM" src="https://github.com/user-attachments/assets/ebc354bb-b0cb-44e0-8f7a-d1e34d02f95e" />


## #️⃣ 연관된 이슈

#54 

## 💡 리뷰어에게 하고 싶은 말
[feat: 카프카 프로듀서 구현](https://github.com/Kernel360/KDEV3_monicar_BE/commit/0ab49f94a6694730b5452116e8b2be726d6624ab) -> 이게 메인 커밋이고, 나머지 커밋은 리팩토링 및 수정이라 안보셔도 됩니다. 전체적인 로직은 이 브랜치 풀 받아서 java/org/emulator/device/infrastructure/GpsTracker.java 만 보시면 될 것 같습니다

+) 지금 주행거리 계산이 좀 이상해서 카프카에 들어간 메세지 까보시면 의아할 수도.. 커큘레이터 손을 좀 봐야할 것 같습니다 ^^7핫 일단 이벤트 퍼블리싱이 되는구나~에 집중하십시다

그리고 지금 @Async로 퍼블리싱하는 메서드를 별도의 스레드에서 실행하도록 했는데, 사실 카프카 이벤트 퍼블리싱 자체가 비동기잖아요? 비동기 작업을 비동기 작업으로 한번 더 감싸준 셈입니다만 ! 에뮬레이터 모듈에 스케줄러가 두개 돌고 있어서 스케줄러 작업에 영향 가지 않게 하려는 의도였습니다. (스케줄링하던 스레드가 그대로 퍼블리싱해도 퍼블리싱이 워낙 얼른 끝나니까 큰 영향이 거의 없습니다만 ! 명시적으로.. 예.. )

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인