### PR TITLE
Feature/#87 response api for vehicle on request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 HELP.md
 .gradle
 build/

--- a/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ResponseCode.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ResponseCode.java
@@ -1,0 +1,37 @@
+package org.controlcenter.common.response.code;
+
+import lombok.Getter;
+
+@Getter
+public enum ResponseCode {
+	SUCCESS("000", "Success"),
+	INVALID_ACCESS_PATH("100", "Invalid access path."),
+	WRONG_APPROACH("101", "This is the wrong approach."),
+	CONTENT_TYPE_ERROR("102", "Content-Type error."),
+	CONTENT_LENGTH_ERROR("103", "Content-Length error."),
+	ACCEPT_ERROR("104", "ACCEPT error."),
+	CACHE_CONTROL_ERROR("105", "Cache-Control error."),
+	ACCEPT_ENCODING_ERROR("106", "Accept-Encoding error"),
+	TIMESTAMP_ERROR("107", "Timestamp error."),
+	TUID_ERROR("108", "TUID error."),
+	MISSING_KEY_VERSION("109", "Missing Key-Version."),
+	NOT_JSON_HEADER_TYPE("110", "Not json header type."),
+	MISSING_TOKEN("200", "Missing Token."),
+	INVALID_TOKEN("201", "Invalid Token."),
+	UNUSABLE_TOKEN("202", "Unusable Token."),
+	PROTOCOL_FORMAT_ERROR("300", "This is a protocol format error."),
+	REQUIRED_PARAMETER_ERROR("301", "Required parameter error."),
+	NO_SEARCH_RESULTS("302", "There are no search results."),
+	DECRYPTION_ERROR("303", "Decryption error."),
+	MISMATCHED_MDN("304", "Mismatched MDN."),
+	DATA_PROCESSING_ERROR("400", "An error occurred while processing data."),
+	UNDEFINED_ERROR("500", "An undetined error has occurred");
+
+	private final String code;
+	private final String message;
+
+	ResponseCode(String code, String message) {
+		this.code = code;
+		this.message = message;
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/domain/Company.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/domain/Company.java
@@ -15,10 +15,10 @@ public class Company {
 	private LocalDateTime updatedAt;
 	private LocalDateTime deletedAt;
 
-    public static Company create(CompanyCreate companyCreate) {
-        return Company.builder()
-                .companyName(companyCreate.getCompanyName())
-                .businessRegistrationNumber(companyCreate.getBusinessRegistrationNumber())
-                .build();
-    }
+	public static Company create(CompanyCreate companyCreate) {
+		return Company.builder()
+			.companyName(companyCreate.getCompanyName())
+			.businessRegistrationNumber(companyCreate.getBusinessRegistrationNumber())
+			.build();
+	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/cycleinfo/domain/GpsStatus.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/cycleinfo/domain/GpsStatus.java
@@ -3,7 +3,8 @@ package org.controlcenter.cycleinfo.domain;
 public enum GpsStatus {
 	A("정상"),
 	V("비정상"),
-	O("미장착");
+	O("미장착"),
+	P("시동 OFF 시 GPS 정보가 비정상");
 
 	private String description;
 

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/VehicleService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/VehicleService.java
@@ -25,13 +25,13 @@ public class VehicleService {
 		return vehicleInformation.getVehicleNumber();
 	}
 
-	public Long getVehicleId(final Long mdn) {
-		VehicleInformation vehicleInformation = vehicleRepository.findByMdn(mdn)
-			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
-		return vehicleInformation.getId();
+	public VehicleEvent saveVehicleEvent(final VehicleEventCreate command) {
+		return vehicleEventRepository.save(VehicleEvent.create(command));
 	}
 
-	public VehicleEvent saveVehicleEvent(VehicleEventCreate command) {
-		 return vehicleEventRepository.save(VehicleEvent.create(command));
+	public VehicleInformation getVehicleInformation(final Long mdn) {
+		return vehicleRepository.findByMdn(mdn)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/VehicleService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/VehicleService.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.transaction.annotation.Transactional;
+
 @RequiredArgsConstructor
 @Service
 public class VehicleService {
@@ -19,16 +21,19 @@ public class VehicleService {
 	private final VehicleRepository vehicleRepository;
 	private final VehicleEventRepository vehicleEventRepository;
 
+	@Transactional(readOnly = true)
 	public String getVehicleNumber(Long vehicleId) {
 		VehicleInformation vehicleInformation = vehicleRepository.findById(vehicleId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
 		return vehicleInformation.getVehicleNumber();
 	}
 
+	@Transactional()
 	public VehicleEvent saveVehicleEvent(final VehicleEventCreate command) {
 		return vehicleEventRepository.save(VehicleEvent.create(command));
 	}
 
+	@Transactional(readOnly = true)
 	public VehicleInformation getVehicleInformation(final Long mdn) {
 		return vehicleRepository.findByMdn(mdn)
 			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/VehicleService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/VehicleService.java
@@ -2,24 +2,36 @@ package org.controlcenter.vehicle.application;
 
 import org.controlcenter.common.exception.BusinessException;
 import org.controlcenter.common.response.code.ErrorCode;
+import org.controlcenter.vehicle.application.port.VehicleEventRepository;
 import org.controlcenter.vehicle.application.port.VehicleRepository;
+import org.controlcenter.vehicle.domain.VehicleEvent;
+import org.controlcenter.vehicle.domain.VehicleEventCreate;
 import org.controlcenter.vehicle.domain.VehicleInformation;
 import org.controlcenter.vehicle.infrastructure.VehicleQueryRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class VehicleService {
 	private final VehicleQueryRepository vehicleQueryRepository;
 	private final VehicleRepository vehicleRepository;
+	private final VehicleEventRepository vehicleEventRepository;
 
 	public String getVehicleNumber(Long vehicleId) {
 		VehicleInformation vehicleInformation = vehicleRepository.findById(vehicleId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
 		return vehicleInformation.getVehicleNumber();
+	}
+
+	public Long getVehicleId(final Long mdn) {
+		VehicleInformation vehicleInformation = vehicleRepository.findByMdn(mdn)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+		return vehicleInformation.getId();
+	}
+
+	public VehicleEvent saveVehicleEvent(VehicleEventCreate command) {
+		 return vehicleEventRepository.save(VehicleEvent.create(command));
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/port/VehicleEventRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/port/VehicleEventRepository.java
@@ -1,0 +1,7 @@
+package org.controlcenter.vehicle.application.port;
+
+import org.controlcenter.vehicle.domain.VehicleEvent;
+
+public interface VehicleEventRepository {
+	VehicleEvent save(VehicleEvent vehicleEvent);
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/port/VehicleRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/port/VehicleRepository.java
@@ -6,4 +6,6 @@ import org.controlcenter.vehicle.domain.VehicleInformation;
 
 public interface VehicleRepository {
 	Optional<VehicleInformation> findById(Long vehicleId);
+	Optional<VehicleInformation> findByMdn(Long mdn);
+
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEvent.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEvent.java
@@ -15,4 +15,12 @@ public class VehicleEvent {
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 	private LocalDateTime deletedAt;
+
+	public static VehicleEvent create(VehicleEventCreate vehicleEventCreate) {
+		return VehicleEvent.builder()
+			.vehicleId(vehicleEventCreate.getVehicleId())
+			.type(vehicleEventCreate.getEventType())
+			.eventAt(vehicleEventCreate.getEventAt())
+			.build();
+	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEventCreate.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEventCreate.java
@@ -1,0 +1,54 @@
+package org.controlcenter.vehicle.domain;
+
+import lombok.Getter;
+import org.controlcenter.common.exception.BusinessException;
+import org.controlcenter.common.response.code.ErrorCode;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+public class VehicleEventCreate {
+	private static final int ON_OFF_TIME_LENGTH = 14; // ccyyMMddHHmmss
+
+	private final long vehicleId;
+	private final VehicleEventType eventType;
+	private final LocalDateTime eventAt;
+
+	private VehicleEventCreate() {
+		this.vehicleId = 0;
+		this.eventType = null;
+		this.eventAt = null;
+	}
+
+	private VehicleEventCreate(
+			final long vehicleId,
+			final VehicleEventType eventType,
+			final LocalDateTime eventAt) {
+		this.vehicleId = vehicleId;
+		this.eventType = eventType;
+		this.eventAt = eventAt;
+	}
+
+	public static VehicleEventCreate of(
+			final long vehicleId,
+			final VehicleEventType onEvent,
+			final String rawEventAt) {
+		LocalDateTime onTime = validateEventAt(rawEventAt);
+
+		return new VehicleEventCreate(
+				vehicleId,
+				onEvent,
+				onTime
+		);
+	}
+
+	private static LocalDateTime validateEventAt(String rawEventAt) {
+		if (rawEventAt.length() != ON_OFF_TIME_LENGTH || !rawEventAt.chars().allMatch(Character::isDigit)) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+
+		DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+		return LocalDateTime.parse(rawEventAt, dateTimeFormat);
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEventCreate.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEventCreate.java
@@ -31,13 +31,18 @@ public class VehicleEventCreate {
 	}
 
 	public static VehicleEventCreate of(
-			final long vehicleId,
+			final long existedVehicleId,
+			final int existedSum,
 			final VehicleEventType onEvent,
-			final String rawEventAt) {
+			final String rawEventAt,
+			final int sum) {
 		LocalDateTime onTime = validateEventAt(rawEventAt);
+		if (existedSum != sum) {
+			throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED);
+		}
 
 		return new VehicleEventCreate(
-				vehicleId,
+				existedVehicleId,
 				onEvent,
 				onTime
 		);

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEventCreate.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleEventCreate.java
@@ -9,7 +9,8 @@ import java.time.format.DateTimeFormatter;
 
 @Getter
 public class VehicleEventCreate {
-	private static final int ON_OFF_TIME_LENGTH = 14; // ccyyMMddHHmmss
+	private static final int EXPECTED_ON_OFF_TIME_LENGTH = 14; // ccyyMMddHHmmss
+	private static final String DATE_TIME_PATTERN = "yyyyMMddHHmmss";
 
 	private final long vehicleId;
 	private final VehicleEventType eventType;
@@ -37,9 +38,7 @@ public class VehicleEventCreate {
 			final String rawEventAt,
 			final int sum) {
 		LocalDateTime onTime = validateEventAt(rawEventAt);
-		if (existedSum != sum) {
-			throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED);
-		}
+		validateSum(existedSum, sum);
 
 		return new VehicleEventCreate(
 				existedVehicleId,
@@ -48,12 +47,31 @@ public class VehicleEventCreate {
 		);
 	}
 
-	private static LocalDateTime validateEventAt(String rawEventAt) {
-		if (rawEventAt.length() != ON_OFF_TIME_LENGTH || !rawEventAt.chars().allMatch(Character::isDigit)) {
+	private static void validateSum(final int existedSum, final int sum) {
+		if (existedSum != sum) {
+			throw new BusinessException(ErrorCode.HANDLE_ACCESS_DENIED);
+		}
+	}
+
+	private static LocalDateTime validateEventAt(final String rawEventAt) {
+		validateFormat(rawEventAt);
+
+		final DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN);
+
+		return LocalDateTime.parse(rawEventAt, dateTimeFormat);
+	}
+
+	private static void validateFormat(final String rawEventAt) {
+		if (!isValidLength(rawEventAt) || !isNumeric(rawEventAt)) {
 			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
 		}
+	}
 
-		DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-		return LocalDateTime.parse(rawEventAt, dateTimeFormat);
+	private static boolean isValidLength(final String rawEventAt) {
+		return rawEventAt.length() == EXPECTED_ON_OFF_TIME_LENGTH;
+	}
+
+	private static boolean isNumeric(final String rawEventAt) {
+		return rawEventAt.chars().allMatch(Character::isDigit);
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/http/request.http
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/http/request.http
@@ -1,0 +1,19 @@
+### 시동 ON 정보 전달(성공)
+POST localhost:8081/api/v1/vehicles/key-on
+Content-Type: application/json
+
+{
+  "mdn": "1010101010",
+  "tid": "TID001",
+  "mid": "1",
+  "pv": "1",
+  "did": "1",
+  "onTime": "20250110202211",
+  "offTime": "20240109112233",
+  "gcd": "A",
+  "lat": "37123456",
+  "lon": "127123456",
+  "ang": "90",
+  "spd": "50",
+  "sum": "10000"
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleEventRepositoryAdapter.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleEventRepositoryAdapter.java
@@ -1,0 +1,19 @@
+package org.controlcenter.vehicle.infrastructure.jpa;
+
+import lombok.RequiredArgsConstructor;
+
+import org.controlcenter.vehicle.application.port.VehicleEventRepository;
+import org.controlcenter.vehicle.domain.VehicleEvent;
+import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleEventEntity;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class VehicleEventRepositoryAdapter implements VehicleEventRepository {
+	private final VehicleEventJpaRepository vehicleEventJpaRepository;
+
+	@Override
+	public VehicleEvent save(VehicleEvent vehicleEvent) {
+		return vehicleEventJpaRepository.save(VehicleEventEntity.from(vehicleEvent)).toDomain();
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleInformationJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleInformationJpaRepository.java
@@ -3,5 +3,9 @@ package org.controlcenter.vehicle.infrastructure.jpa;
 import org.controlcenter.vehicle.infrastructure.jpa.entity.VehicleInformationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface VehicleInformationJpaRepository extends JpaRepository<VehicleInformationEntity, Long> {
+	Optional<VehicleInformationEntity> findByMdn(Long mdn);
+
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleInformationRepositoryAdapter.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/VehicleInformationRepositoryAdapter.java
@@ -19,4 +19,11 @@ public class VehicleInformationRepositoryAdapter implements VehicleRepository {
 		return vehicleInformationJpaRepository.findById(vehicleId)
 			.map(VehicleInformationEntity::toDomain);
 	}
+
+	@Override
+	public Optional<VehicleInformation> findByMdn(Long mdn) {
+		return vehicleInformationJpaRepository.findByMdn(mdn)
+			.map(VehicleInformationEntity::toDomain);
+	}
+
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
@@ -4,10 +4,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.controlcenter.common.response.BaseResponse;
-import org.controlcenter.common.response.code.ErrorCode;
 import org.controlcenter.common.response.code.ResponseCode;
 import org.controlcenter.vehicle.application.VehicleService;
 import org.controlcenter.vehicle.domain.VehicleEventCreate;
+import org.controlcenter.vehicle.domain.VehicleInformation;
 import org.controlcenter.vehicle.infrastructure.VehicleQueryRepository;
 import org.controlcenter.vehicle.presentation.dto.CommonResponse;
 import org.controlcenter.vehicle.presentation.dto.RouteResponse;
@@ -68,12 +68,9 @@ public class VehicleController {
 		 * TODO 토큰 확인 로직 추가
 		 */
 
-		final Long vehicleId = vehicleService.getVehicleId(request.mdn());
-		if (vehicleId == null) {
-			return BaseResponse.fail(ErrorCode.INVALID_INPUT_VALUE);
-		}
+		final VehicleInformation vehicleInformation = vehicleService.getVehicleInformation(request.mdn());
 
-		VehicleEventCreate vehicleEventCreate = request.toDomain(vehicleId);
+		VehicleEventCreate vehicleEventCreate = request.toDomain(vehicleInformation.getId(), vehicleInformation.getSum());
 		vehicleService.saveVehicleEvent(vehicleEventCreate);
 
 		CommonResponse response = new CommonResponse(

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
@@ -1,8 +1,5 @@
 package org.controlcenter.vehicle.presentation;
 
-import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -29,7 +26,6 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("api/v1/vehicles")
@@ -71,7 +67,6 @@ public class VehicleController {
 		/*
 		 * TODO 토큰 확인 로직 추가
 		 */
-		log.info("keyOnReq: {}", request);
 
 		final Long vehicleId = vehicleService.getVehicleId(request.mdn());
 		if (vehicleId == null) {

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
@@ -1,17 +1,27 @@
 package org.controlcenter.vehicle.presentation;
 
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 import org.controlcenter.common.response.BaseResponse;
+import org.controlcenter.common.response.code.ErrorCode;
+import org.controlcenter.common.response.code.ResponseCode;
 import org.controlcenter.vehicle.application.VehicleService;
+import org.controlcenter.vehicle.domain.VehicleEventCreate;
 import org.controlcenter.vehicle.infrastructure.VehicleQueryRepository;
+import org.controlcenter.vehicle.presentation.dto.CommonResponse;
 import org.controlcenter.vehicle.presentation.dto.RouteResponse;
+import org.controlcenter.vehicle.presentation.dto.KeyOnRequest;
 import org.controlcenter.vehicle.presentation.dto.VehicleInfoResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleInfoSearchRequest;
 import org.controlcenter.vehicle.presentation.dto.VehicleRouteResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("api/v1/vehicles")
@@ -43,12 +54,39 @@ public class VehicleController {
 	) {
 		String vehicleNumber = vehicleService.getVehicleNumber(vehicleId);
 
-		List<RouteResponse> routesResponses = vehicleQueryRepository.getVehicleRouteFrom(vehicleId, startTime, endTime, interval);
+		List<RouteResponse> routesResponses = vehicleQueryRepository.getVehicleRouteFrom(vehicleId, startTime, endTime,
+			interval);
 
 		VehicleRouteResponse response = VehicleRouteResponse.builder()
 			.vehicleNumber(vehicleNumber)
 			.routes(routesResponses)
 			.build();
+		return BaseResponse.success(response);
+	}
+
+	@PostMapping("/key-on")
+	public BaseResponse<CommonResponse> keyOn(
+		@Valid @RequestBody final KeyOnRequest request
+	) {
+		/*
+		 * TODO 토큰 확인 로직 추가
+		 */
+		log.info("keyOnReq: {}", request);
+
+		final Long vehicleId = vehicleService.getVehicleId(request.mdn());
+		if (vehicleId == null) {
+			return BaseResponse.fail(ErrorCode.INVALID_INPUT_VALUE);
+		}
+
+		VehicleEventCreate vehicleEventCreate = request.toDomain(vehicleId);
+		vehicleService.saveVehicleEvent(vehicleEventCreate);
+
+		CommonResponse response = new CommonResponse(
+			ResponseCode.SUCCESS.getCode(),
+			ResponseCode.SUCCESS.getMessage(),
+			request.mdn().toString()
+		);
+
 		return BaseResponse.success(response);
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/CommonResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/CommonResponse.java
@@ -1,0 +1,8 @@
+package org.controlcenter.vehicle.presentation.dto;
+
+public record CommonResponse(
+	String rstCd,
+	String rstMsg,
+	String mdn
+) {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/KeyOnRequest.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/KeyOnRequest.java
@@ -37,11 +37,13 @@ public record KeyOnRequest(
 		@NotNull(message = "누적 주행 거리는 비어 있을 수 없습니다.")
 		Integer sum
 ) {
-	public VehicleEventCreate toDomain(final Long vehicleId) {
+	public VehicleEventCreate toDomain(final Long existedVehicleId, final int existedSum) {
 		return VehicleEventCreate.of(
-				vehicleId,
+				existedVehicleId,
+				existedSum,
 				VehicleEventType.ON,
-				onTime
+				onTime,
+				sum
 		);
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/KeyOnRequest.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/KeyOnRequest.java
@@ -1,0 +1,47 @@
+package org.controlcenter.vehicle.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import org.controlcenter.cycleinfo.domain.GpsStatus;
+import org.controlcenter.vehicle.domain.VehicleEventCreate;
+import org.controlcenter.vehicle.domain.VehicleEventType;
+
+import java.math.BigDecimal;
+
+public record KeyOnRequest(
+		@NotNull(message = "차량 번호는 비어 있을 수 없습니다.")
+		Long mdn,
+		@NotBlank(message = "터미널 아이디는 null 또는 비어 있을 수 없습니다.")
+		String tid,
+		@NotNull(message = "제조사 아이디는 비어 있을 수 없습니다.")
+		Integer mid,
+		@NotNull(message = "패킷 버전은 비어 있을 수 없습니다.")
+		Integer pv,
+		@NotNull(message = "디바이스 아이디는 비어 있을 수 없습니다.")
+		Integer did,
+		@NotBlank(message = "차량 시동 On 시간은 비어 있을 수 없습니다.")
+		String onTime,
+		@NotBlank(message = "차량 시동 Off 시간은 비어 있을 수 없습니다.")
+		String offTime,
+		@NotNull(message = "GPS 상태는 null 또는 비어 있을 수 없습니다.")
+		GpsStatus gcd,
+		@NotNull(message = "GPS 위도는 비어 있을 수 없습니다.")
+		BigDecimal lat,
+		@NotNull(message = "GPS 경도는 비어 있을 수 없습니다.")
+		BigDecimal lon,
+		@NotNull(message = "방향은 비어 있을 수 없습니다.")
+		Integer ang,
+		@NotNull(message = "속도는 비어 있을 수 없습니다.")
+		Integer spd,
+		@NotNull(message = "누적 주행 거리는 비어 있을 수 없습니다.")
+		Integer sum
+) {
+	public VehicleEventCreate toDomain(final Long vehicleId) {
+		return VehicleEventCreate.of(
+				vehicleId,
+				VehicleEventType.ON,
+				onTime
+		);
+	}
+}


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->
- `monicar-control-center`모듈에서 차량 ON API 구현
  - 존재하는 차량인지 확인
  - 시동 ON 정보 전달을 요청할 경우, 요청 전문 헤더 부분의 Token 값 확인 -> 해당 로직은 TODO 주석으로만 남김
  - 시동 ON 시 최초 누적거리는 그 직전 시동 OFF일 때의 누적 거리 값과 일치 확인
  - 차량이벤트 테이블에 데이터 저장
## #️⃣ 연관된 이슈

<!-- ex) #이슈번호, #이슈번호 -->
#87 

## 💡 리뷰어에게 하고 싶은 말
- `request.http` 파일을 통해 데이터가 잘 저장되는지 테스트하고 저장되는 것을 확인했습니다.
  - DB에 테이블이 이미 있는 경우 `application-dev.yml`파일에서 아래와 같이 주석처리해야 `ControlCenterApplication`이 실행됩니다. 
    ```yml
      sql:
        init:
          mode: always
    #      schema-locations: classpath:/schema/init-schema.sql
    #      data-locations: classpath:/data/init-data.sql
    ```
- 클라이언트의 요청을 받아서 데이터를 저장하는 것을 목표로 구현했습니다. 
  프로젝트 내에서 다른 코드를 참고하며 최대한 결을 따라가려고 했는데, 부족하거나 더 좋은 수정 방향이 있다면 가감없이 코멘트 남겨주세요🙏
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인