### PR TITLE
feature: 애뮬레이터 내 프로듀서 코드 분리

### DIFF
--- a/monicar-producer/build.gradle
+++ b/monicar-producer/build.gradle
@@ -1,0 +1,13 @@
+tasks.bootJar {
+    enabled = true
+}
+
+tasks.jar {
+    enabled = true
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation "org.springframework.kafka:spring-kafka:3.3.0"
+}
+

--- a/monicar-producer/src/main/java/org/producer/ProducerApplication.java
+++ b/monicar-producer/src/main/java/org/producer/ProducerApplication.java
@@ -1,0 +1,13 @@
+package org.producer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ProducerApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ProducerApplication.class, args);
+	}
+
+}

--- a/monicar-producer/src/main/java/org/producer/common/constant/VehicleConstant.java
+++ b/monicar-producer/src/main/java/org/producer/common/constant/VehicleConstant.java
@@ -1,0 +1,20 @@
+package org.producer.common.constant;
+
+import org.producer.common.exception.BusinessException;
+import org.producer.common.response.ErrorCode;
+
+public final class VehicleConstant {
+	public static final long VEHICLE_PRIMARY_KEY = 1234567890L;
+	public static final String VEHICLE_NUMBER = "12나3456";
+	public static final String TERMINAL_ID = "A001";
+	public static final long MANUFACTURER_ID = 6L;
+	public static final int PACKET_VERSION = 5;
+	public static final long DEVICE_ID = 1L;
+	public static final int BATTERY = 100;
+
+	public static final long MIL = 1_000_000;
+
+	private VehicleConstant() {
+		throw new BusinessException(ErrorCode.ILLEGAL_UTILITY_CLASS_ACCESS);
+	}
+}

--- a/monicar-producer/src/main/java/org/producer/common/exception/BusinessException.java
+++ b/monicar-producer/src/main/java/org/producer/common/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package org.producer.common.exception;
+
+import org.producer.common.response.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+	private final ErrorCode errorCode;
+
+	public BusinessException(String message, ErrorCode errorCode) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/monicar-producer/src/main/java/org/producer/common/response/ErrorCode.java
+++ b/monicar-producer/src/main/java/org/producer/common/response/ErrorCode.java
@@ -1,0 +1,16 @@
+package org.producer.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+	UNSUPPORTED_HEADER(1002, "지원되지 않는 헤더가 입력되었습니다"),
+	ILLEGAL_UTILITY_CLASS_ACCESS(1003, "유틸리티 클래스에 대한 잘못된 접근입니다"),
+	INTERNAL_SERVER_ERROR(1004, "서버 오류가 발생하였습니다");
+
+	private final int code;
+	private final String message;
+}
+

--- a/monicar-producer/src/main/java/org/producer/config/KafkaConfig.java
+++ b/monicar-producer/src/main/java/org/producer/config/KafkaConfig.java
@@ -1,0 +1,49 @@
+package org.producer.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.producer.producer.TypeIdInterceptor;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+
+@Configuration
+public class KafkaConfig {
+
+	@Bean
+	@Primary
+	@ConfigurationProperties("spring.kafka")
+	public KafkaProperties kafkaProperties() {
+		return new KafkaProperties();
+	}
+
+	@Bean
+	public ProducerFactory<String, Object> producerFactory(KafkaProperties kafkaProperties) {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, kafkaProperties.getProducer().getKeySerializer());
+		props.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, TypeIdInterceptor.class.getName());
+		props.put(ProducerConfig.ACKS_CONFIG, kafkaProperties.getProducer().getAcks());
+
+		JsonSerializer<Object> jsonSerializer = new JsonSerializer<>();
+		jsonSerializer.setAddTypeInfo(false);
+
+		return new DefaultKafkaProducerFactory<>(props,
+			new org.apache.kafka.common.serialization.StringSerializer(),
+			jsonSerializer);
+	}
+
+	@Bean
+	public KafkaTemplate<String, Object> kafkaTemplate(KafkaProperties kafkaProperties) {
+		return new KafkaTemplate<>(producerFactory(kafkaProperties));
+	}
+}

--- a/monicar-producer/src/main/java/org/producer/dto/CycleInfoCommand.java
+++ b/monicar-producer/src/main/java/org/producer/dto/CycleInfoCommand.java
@@ -1,0 +1,19 @@
+package org.producer.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.Builder;
+
+@Builder
+public record CycleInfoCommand(
+	@JsonFormat(pattern = "yyyyMMddHHmmss") LocalDateTime intervalAt,
+	GpsStatus gcd,
+	long lat,
+	long lon,
+	int ang,
+	int spd,
+	int sum
+) {
+}

--- a/monicar-producer/src/main/java/org/producer/dto/CycleInfoListCommand.java
+++ b/monicar-producer/src/main/java/org/producer/dto/CycleInfoListCommand.java
@@ -1,0 +1,19 @@
+package org.producer.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record CycleInfoListCommand(
+	long mdn,
+	String tid,
+	long mid,
+	int pv,
+	long did,
+	int cCnt,
+	List<CycleInfoCommand> cList
+) {
+
+}
+

--- a/monicar-producer/src/main/java/org/producer/dto/FixedVehicleInfo.java
+++ b/monicar-producer/src/main/java/org/producer/dto/FixedVehicleInfo.java
@@ -1,0 +1,30 @@
+package org.producer.dto;
+
+import org.producer.common.constant.VehicleConstant;
+
+import lombok.Getter;
+
+@Getter
+public class FixedVehicleInfo {
+	private static final FixedVehicleInfo INSTANCE = new FixedVehicleInfo();
+
+	private final long mdn;
+	private final String num;
+	private final String tid;
+	private final long mid;
+	private final int pv;
+	private final long did;
+
+	private FixedVehicleInfo() {
+		this.mdn = VehicleConstant.VEHICLE_PRIMARY_KEY;
+		this.num = VehicleConstant.VEHICLE_NUMBER;
+		this.tid = VehicleConstant.TERMINAL_ID;
+		this.mid = VehicleConstant.MANUFACTURER_ID;
+		this.pv = VehicleConstant.PACKET_VERSION;
+		this.did = VehicleConstant.DEVICE_ID;
+	}
+
+	public static FixedVehicleInfo getInstance() {
+		return INSTANCE;
+	}
+}

--- a/monicar-producer/src/main/java/org/producer/dto/GpsStatus.java
+++ b/monicar-producer/src/main/java/org/producer/dto/GpsStatus.java
@@ -1,0 +1,5 @@
+package org.producer.dto;
+
+public enum GpsStatus {
+	A
+}

--- a/monicar-producer/src/main/java/org/producer/producer/CycleInfoEventPublisher.java
+++ b/monicar-producer/src/main/java/org/producer/producer/CycleInfoEventPublisher.java
@@ -1,0 +1,7 @@
+package org.producer.producer;
+
+import org.producer.dto.CycleInfoListCommand;
+
+public interface CycleInfoEventPublisher {
+	void publishEvent(CycleInfoListCommand cycleInfoListCommand);
+}

--- a/monicar-producer/src/main/java/org/producer/producer/KafkaCycleInfoEventPublisher.java
+++ b/monicar-producer/src/main/java/org/producer/producer/KafkaCycleInfoEventPublisher.java
@@ -1,0 +1,24 @@
+package org.producer.producer;
+
+import org.producer.dto.CycleInfoListCommand;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KafkaCycleInfoEventPublisher implements CycleInfoEventPublisher{
+
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+
+	@Override
+	@Async
+	public void publishEvent(CycleInfoListCommand message) {
+		log.info("[Thread: {}] {}", Thread.currentThread().getName(), "publish message. . .");
+		kafkaTemplate.send("cycleInfo-json-topic", String.valueOf(message.mdn()), message);
+	}
+}

--- a/monicar-producer/src/main/java/org/producer/producer/TypeIdInterceptor.java
+++ b/monicar-producer/src/main/java/org/producer/producer/TypeIdInterceptor.java
@@ -1,0 +1,40 @@
+package org.producer.producer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerInterceptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TypeIdInterceptor implements ProducerInterceptor<String, Object> {
+	private static final String TYPE_ID_KEY = "__TypeId__";
+	private static final String CONSUMER_CLASS_PACKAGE_PATH = "org.collector.presentation.dto.CycleInfoRequest";
+
+	@Override
+	public ProducerRecord<String, Object> onSend(ProducerRecord<String, Object> producerRecord) {
+		producerRecord.headers().add(
+			TYPE_ID_KEY,
+			CONSUMER_CLASS_PACKAGE_PATH.getBytes(StandardCharsets.UTF_8)
+		);
+		return producerRecord;
+	}
+
+	@Override
+	public void onAcknowledgement(RecordMetadata recordMetadata, Exception e) {
+
+	}
+
+	@Override
+	public void close() {
+
+	}
+
+	@Override
+	public void configure(Map<String, ?> map) {
+
+	}
+}

--- a/monicar-producer/src/main/resources/application.yml
+++ b/monicar-producer/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+server:
+  port: 8082
+
+spring:
+  application:
+    name: monicar-producer
+
+  kafka:
+    bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: 1
+
+logging:
+  level:
+    org:
+      apache:
+        hc:
+          client5:
+            http=DEBUG:

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,4 +4,5 @@ include 'monicar-control-center'
 include 'monicar-collector'
 include 'monicar-common'
 include 'monicar-track-alert'
+include 'monicar-producer'
 


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

애뮬레이터 내 프로듀서 코드 분리

## #️⃣ 연관된 이슈

#121 

## 💡 리뷰어에게 하고 싶은 말
- 현재 대강 프로듀서 구현을 위한 요청dto, 카프카 설정 (Config, KafkaCycleInfoEventPublisher, TypeIdInterceptor) 부분만 그대로 복사하였습니다.
- 패키지 구조, 클래스 명 등 은 지윤님께서 보시고 수정하시고 싶은 부분 수정하시면 될듯합니다. 
- 당연히 애뮬레이터 내에 구현된 프로듀서쪽은 언젠가 삭제되어야겠지만, 향후 개발하시면서 해당 코드가 필요할 때가 있을 것 같아 삭제하지 않겠습니다. 
- **애뮬레이터에 Producer가 있든, Producer가 별도로 있든 운영환경을 고려하신다면, TypeIdInterceptor는 Json방식이든 간에 어떤 방식으로든 수정되어야할 듯 합니다.**
- 왜냐하면, 프로듀서가 있는 서버는 org.collector.presentation.dto.CycleInfoRequest패키지 경로를 모르기 때문입니다.
- **아까 대면으로, 컨슈머의 패키지 경로를 파악하고 작성하신다고 하셨는데,** 
- **언젠가 컨슈머도 여러개 띄워지고, 프로듀서도 여러개 띄워질땐 대면으로 말씀해주신 방식이 가능할지 모르겠네요.** 🤔

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인