### PR TITLE
feat: event-hub 모듈 health-check-api 추가

### DIFF
--- a/monicar-event-hub/build.gradle
+++ b/monicar-event-hub/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     implementation 'org.springframework.kafka:spring-kafka:3.3.0'
 

--- a/monicar-event-hub/src/main/java/org/eventhub/config/SecurityConfig.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/config/SecurityConfig.java
@@ -1,0 +1,19 @@
+package org.eventhub.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig{
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/").permitAll()
+				.anyRequest().authenticated()
+			);
+		return http.build();
+	}
+}

--- a/monicar-event-hub/src/main/java/org/eventhub/presentation/HealthCheckController.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/presentation/HealthCheckController.java
@@ -1,0 +1,14 @@
+package org.eventhub.presentation;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+	@GetMapping("/")
+	public ResponseEntity<HttpStatus> healthCheck(){
+		return new ResponseEntity<>(HttpStatus.OK);
+	}
+}


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

event-hub 모듈 내 health-check-api를 추가하였습니다.

## #️⃣ 연관된 이슈

#176 

## 💡 리뷰어에게 하고 싶은 말

- 어제 말씀드린대로, ALB가 여러 서버들에게 요청을 보낼때 특정 서버가 살았는지 죽었는지를 확인하기 위한 API가 필요하여 이를 위한 기능을 추가하였습니다.

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인