### PR TITLE
refactor: 파티션 여러개 분리함에 따라 필요한 부분 수정

### DIFF
--- a/monicar-collector/src/main/java/org/collector/config/KafkaConfig.java
+++ b/monicar-collector/src/main/java/org/collector/config/KafkaConfig.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -67,5 +68,10 @@ public class KafkaConfig {
 	@Bean
 	public KafkaTemplate<String, ?> kafkaTemplate(KafkaProperties kafkaProperties) {
 		return new KafkaTemplate<>(producerFactory(kafkaProperties));
+	}
+
+	@Bean
+	public PartitionFinder finder(@Qualifier("consumerFactory") ConsumerFactory<String, Object> consumerFactory) {
+		return new PartitionFinder(consumerFactory);
 	}
 }

--- a/monicar-collector/src/main/java/org/collector/config/PartitionFinder.java
+++ b/monicar-collector/src/main/java/org/collector/config/PartitionFinder.java
@@ -1,0 +1,23 @@
+package org.collector.config;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PartitionFinder {
+
+	private final ConsumerFactory<String, Object> consumerFactory;
+
+	public String[] partitions(String topic) {
+		try (Consumer<String, Object> consumer = consumerFactory.createConsumer()) {
+			return consumer.partitionsFor(topic).stream()
+				.map(pi -> "" + pi.partition())
+				.toArray(String[]::new);
+		}
+	}
+
+}

--- a/monicar-collector/src/main/java/org/collector/consumer/CycleInfoConsumer.java
+++ b/monicar-collector/src/main/java/org/collector/consumer/CycleInfoConsumer.java
@@ -4,6 +4,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.collector.application.CycleInfoService;
 import org.collector.presentation.dto.CycleInfoRequest;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.TopicPartition;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -13,10 +14,8 @@ import lombok.RequiredArgsConstructor;
 public class CycleInfoConsumer {
 	private final CycleInfoService cycleInfoService;
 
-	@KafkaListener(
-		topics = { "cycleInfo-json-topic" },
-		groupId = "consumer-group"
-	)
+	@KafkaListener(topicPartitions = @TopicPartition(topic = "cycleInfo-json-topic",
+		partitions = "#{@finder.partitions('cycleInfo-json-topic')}"))
 	public void accept(ConsumerRecord<String, CycleInfoRequest> message) {
 		System.out.println("[Main Consumer] Message arrived! - " + message.value());
 		cycleInfoService.cycleInfoSave(message.value());


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

파티션 여러개 분리하기 위해 설정작업 변경

## #️⃣ 연관된 이슈

#215 

## 💡 리뷰어에게 하고 싶은 말

- 파티션을 여러개 분리함에 따라 동적으로 파티션 목록을 찾도록 코드 수정하였습니다.
- finder를 bean으로 등록하여 Consumer에서 파티션을 찾기위해 partitionsFor메소드 이용하였습니다.


* [공식문서](https://docs.spring.io/spring-kafka/reference/tips.html#tip-assign-all-parts) 참조

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인