### PR TITLE
feature: 일별 운행기록 API 구현

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/common/util/CookieUtil.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/util/CookieUtil.java
@@ -11,6 +11,8 @@ public class CookieUtil {
 		return ResponseCookie.from("access_token", value)
 			.maxAge(maxAgeSec)
 			.path("/")
+			.secure(true)
+			.sameSite("None")
 			.httpOnly(true)
 			.build();
 	}
@@ -21,6 +23,8 @@ public class CookieUtil {
 		return ResponseCookie.from("refresh_token", value)
 			.maxAge(maxAgeSec)
 			.path("/")
+			.secure(true)
+			.sameSite("None")
 			.httpOnly(true)
 			.build();
 	}

--- a/monicar-control-center/src/main/java/org/controlcenter/company/presentation/AuthController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/presentation/AuthController.java
@@ -5,6 +5,7 @@ import org.controlcenter.common.response.BaseResponse;
 import org.controlcenter.common.response.code.ErrorCode;
 import org.controlcenter.common.util.CookieUtil;
 import org.controlcenter.company.application.AuthService;
+import org.controlcenter.company.presentation.swagger.AuthApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
-public class AuthController {
+public class AuthController implements AuthApi {
 
 	private final AuthService authService;
 	private final CookieUtil cookieUtil;

--- a/monicar-control-center/src/main/java/org/controlcenter/company/presentation/CompanyController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/presentation/CompanyController.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/v1/companies")
+@RequestMapping("/api/v1")
 public class CompanyController {
 	private final CompanyService companyService;
 
@@ -24,7 +24,7 @@ public class CompanyController {
 	 * @param companyCreateRequest 업체(회사) 등록 요청 데이터
 	 * @return 등록된 업체 데이터를 반환
 	 */
-	@PostMapping
+	@PostMapping("/company")
 	public BaseResponse<SimpleCompanyResponse> register(
 		@Valid @RequestBody CompanyCreateRequest companyCreateRequest
 	) {

--- a/monicar-control-center/src/main/java/org/controlcenter/company/presentation/swagger/AuthApi.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/presentation/swagger/AuthApi.java
@@ -1,2 +1,31 @@
-package org.controlcenter.company.presentation.swagger;public class AuthApi {
+package org.controlcenter.company.presentation.swagger;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Tag(name = "토큰 재발급 API", description = "사용자 관련 토큰 재발급 기능 API")
+public interface AuthApi {
+
+	@Operation(summary = "액세스 토큰 재발급 API",
+		description = "리프레시 토큰으로 액세스 토큰 재발급")
+	@PostMapping("/logout")
+	ResponseEntity<?> refreshAccessToken(
+		@Parameter(hidden = true) @CookieValue(value = "access_token", required = false) String accessToken,
+		@Parameter(hidden = true) @CookieValue("refresh_token") String refreshToken,
+		HttpServletResponse response
+	);
+
+	@Operation(summary = "리프레시 토큰 재발급 API",
+		description = "액세스 토큰으로 리프레시 토큰 재발급")
+	ResponseEntity<?> reissueRefreshToken(
+		@Parameter(hidden = true) @CookieValue("access_token") String accessToken,
+		@Parameter(hidden = true) @CookieValue(value = "refresh_token", required = false) String oldRefreshToken,
+		HttpServletResponse response
+	);
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/company/presentation/swagger/AuthApi.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/company/presentation/swagger/AuthApi.java
@@ -1,0 +1,2 @@
+package org.controlcenter.company.presentation.swagger;public class AuthApi {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/notice/presentation/NoticeController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/notice/presentation/NoticeController.java
@@ -17,11 +17,11 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/v1/control-center")
+@RequestMapping("/api/v1")
 public class NoticeController {
 	private final NoticeRepository repository;
 
-	@GetMapping("/notices")
+	@GetMapping("/notice")
 	public BaseResponse<List<SimpleNoticeResponse>> getAllNotice() {
 		List<SimpleNoticeResponse> notices = repository.findAll()
 			.stream()
@@ -33,7 +33,7 @@ public class NoticeController {
 		return BaseResponse.success(notices);
 	}
 
-	@GetMapping("/notices/{notice-id}")
+	@GetMapping("/notice/{notice-id}")
 	public BaseResponse<SimpleNoticeResponse> getNotice(
 		@PathVariable("notice-id") Long noticeId
 	) {

--- a/monicar-control-center/src/main/java/org/controlcenter/notice/presentation/NoticeController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/notice/presentation/NoticeController.java
@@ -28,8 +28,6 @@ public class NoticeController {
 			.map(SimpleNoticeResponse::from)
 			.toList();
 
-		if (notices.isEmpty()) return BaseResponse.fail(ErrorCode.ENTITY_NOT_FOUND);
-
 		return BaseResponse.success(notices);
 	}
 

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/DrivingLogService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/DrivingLogService.java
@@ -1,17 +1,21 @@
 package org.controlcenter.vehicle.application;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import org.controlcenter.common.exception.BusinessException;
 import org.controlcenter.common.response.code.ErrorCode;
+import org.controlcenter.history.infrastructure.jpa.DrivingHistoryJpaRepository;
 import org.controlcenter.vehicle.application.port.DrivingLogRepository;
 import org.controlcenter.vehicle.application.port.VehicleRepository;
 import org.controlcenter.vehicle.domain.BusinessInfo;
+import org.controlcenter.vehicle.domain.DailyDrivingSummary;
 import org.controlcenter.vehicle.domain.DrivingLog;
 import org.controlcenter.vehicle.domain.DrivingLogDetailsContent;
 import org.controlcenter.vehicle.domain.DrivingLogSummary;
+import org.controlcenter.vehicle.domain.Period;
 import org.controlcenter.vehicle.domain.SpecificVehicleInformation;
 import org.controlcenter.vehicle.domain.VehicleHeaderInfo;
 import org.controlcenter.vehicle.domain.VehicleSortType;
@@ -28,6 +32,18 @@ import lombok.RequiredArgsConstructor;
 public class DrivingLogService {
 	private final DrivingLogRepository drivingLogRepository;
 	private final VehicleRepository vehicleRepository;
+	private final DrivingHistoryJpaRepository drivingHistoryJpaRepository;
+
+	public List<DailyDrivingSummary> getDailySummaries(Long vehicleId, Period period) {
+		LocalDateTime end = LocalDateTime.now();
+		LocalDateTime start = switch (period) {
+			case WEEK -> end.minusWeeks(1);
+			case MONTH -> end.minusMonths(1);
+			case THREE_MONTHS -> end.minusMonths(3);
+		};
+
+		return drivingLogRepository.getDailySummaries(vehicleId, start, end);
+	}
 
 	@Transactional(readOnly = true)
 	public Page<DrivingLog> getDrivingLogList(String vehicleNumber, VehicleSortType vehicleSortType,

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/port/DrivingLogRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/port/DrivingLogRepository.java
@@ -1,8 +1,10 @@
 package org.controlcenter.vehicle.application.port;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
+import org.controlcenter.vehicle.domain.DailyDrivingSummary;
 import org.controlcenter.vehicle.domain.DrivingLog;
 import org.controlcenter.vehicle.domain.DrivingLogDetailsContent;
 import org.controlcenter.vehicle.domain.VehicleHeaderInfo;
@@ -11,6 +13,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface DrivingLogRepository {
+	List<DailyDrivingSummary> getDailySummaries(Long vehicleId, LocalDateTime start, LocalDateTime end);
+
 	Page<DrivingLog> findByVehicleNumber(String vehicleNumber, VehicleSortType sortType, Pageable pageable);
 
 	VehicleHeaderInfo findVehicleHeaderInfoByVehicleId(Long vehicleId);

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/DailyDrivingSummary.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/DailyDrivingSummary.java
@@ -1,0 +1,25 @@
+package org.controlcenter.vehicle.domain;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyDrivingSummary {
+	private LocalDate drivingDate;
+	private Integer totalDistance;
+	private Long totalDrivingSeconds;
+
+	@QueryProjection
+	public DailyDrivingSummary(Date drivingDate, Integer totalDistance, Long totalDrivingSeconds) {
+		this.drivingDate = drivingDate.toLocalDate();
+		this.totalDistance = totalDistance;
+		this.totalDrivingSeconds = totalDrivingSeconds;
+	}
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/Period.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/Period.java
@@ -1,0 +1,5 @@
+package org.controlcenter.vehicle.domain;
+
+public enum Period {
+	WEEK, MONTH, THREE_MONTHS
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/DrivingLogController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/DrivingLogController.java
@@ -7,7 +7,9 @@ import org.controlcenter.common.response.BaseResponse;
 import org.controlcenter.common.response.PageResponse;
 import org.controlcenter.vehicle.application.DrivingLogService;
 import org.controlcenter.vehicle.application.port.VehicleTypeRepository;
+import org.controlcenter.vehicle.domain.DailyDrivingSummary;
 import org.controlcenter.vehicle.domain.DrivingLog;
+import org.controlcenter.vehicle.domain.Period;
 import org.controlcenter.vehicle.domain.VehicleSortType;
 import org.controlcenter.vehicle.presentation.dto.DrivingLogResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleDrivingLogDetailsResponse;
@@ -31,6 +33,14 @@ import lombok.RequiredArgsConstructor;
 public class DrivingLogController implements DrivingLogApi {
 	private final DrivingLogService drivingLogService;
 	private final VehicleTypeRepository vehicleTypeRepository;
+
+	@GetMapping("/daily/{vehicle-id}")
+	public BaseResponse<List<DailyDrivingSummary>> getDailyDrivingSummary(
+		@PathVariable("vehicle-id") Long vehicleId,
+		@RequestParam(required = false, defaultValue = "WEEK") Period period
+	){
+		return BaseResponse.success(drivingLogService.getDailySummaries(vehicleId, period));
+	}
 
 	@GetMapping("/{vehicle-id}")
 	public BaseResponse<VehicleDrivingLogDetailsResponse> getDrivingLogByVehicleId(

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/DrivingLogController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/DrivingLogController.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1/driving-log")
+@RequestMapping("/api/v1/log")
 public class DrivingLogController implements DrivingLogApi {
 	private final DrivingLogService drivingLogService;
 	private final VehicleTypeRepository vehicleTypeRepository;

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
@@ -39,7 +39,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("api/v1/vehicles")
+@RequestMapping("api/v1/vehicle")
 public class VehicleController implements VehicleApi {
 	private final VehicleQueryRepository vehicleQueryRepository;
 	private final VehicleClusteringService vehicleClusteringService;


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- 일별 운행기록 API 구현
- https로 인한 쿠키 설정 변경
- 엔드포인트 통일, 단수형으로 변경
- 토큰 관련 API 문서화 추가
<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#229
<!-- ex) #이슈번호, #이슈번호 -->

## 💡 리뷰어에게 하고 싶은 말

- 엔드포인트가 통일되지 않아서 수정하였습니다.
- https로 인한 쿠키 설정 변경(프론트엔드 문제)

- Period enum(일주일, 1개월, 3개월)로 구분하여 조회되도록 QueryDSL로 구현하였습니다.
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인