### PR TITLE
fix: 환경에 따른 쿠키 도메인이 변경되도록 수정

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/common/util/CookieUtil.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/util/CookieUtil.java
@@ -1,10 +1,14 @@
 package org.controlcenter.common.util;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CookieUtil {
+	@Value("${cookie.domain}")
+	private String cookieDomain;
+
 	public ResponseCookie createAccessTokenCookie(String value, Long expirationMillis) {
 		int maxAgeSec = (int)(expirationMillis / 1000);
 
@@ -13,6 +17,7 @@ public class CookieUtil {
 			.path("/")
 			.secure(true)
 			.sameSite("None")
+			.domain(cookieDomain)
 			.httpOnly(true)
 			.build();
 	}
@@ -25,6 +30,7 @@ public class CookieUtil {
 			.path("/")
 			.secure(true)
 			.sameSite("None")
+			.domain(cookieDomain)
 			.httpOnly(true)
 			.build();
 	}

--- a/monicar-control-center/src/main/resources/application-dev.yml
+++ b/monicar-control-center/src/main/resources/application-dev.yml
@@ -33,9 +33,9 @@ spring:
       port: 6379
 
   datasource:
-    url: jdbc:mysql://localhost:3306/monicar_db
-    username: local_user
-    password: local_password
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/monicar-control-center/src/main/resources/application-dev.yml
+++ b/monicar-control-center/src/main/resources/application-dev.yml
@@ -45,3 +45,6 @@ jwt:
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+
+cookie:
+  domain: ${COOKIE_DOMAIN}

--- a/monicar-control-center/src/main/resources/application-prod.yml
+++ b/monicar-control-center/src/main/resources/application-prod.yml
@@ -45,3 +45,6 @@ jwt:
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+
+cookie:
+  domain: ${COOKIE_DOMAIN}


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- 환경에 따른 쿠키 도메인이 변경되도록 수정
<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#251 
<!-- ex) #이슈번호, #이슈번호 -->

## 💡 리뷰어에게 하고 싶은 말

- 프론트 쿠키 도메인 고정하여 사용하기 위해 환경에 맞춰 쿠키 도메인이 변경되도록 수정하였습니다.
- ⭐️해당 환경 변수는 BE Page 최하단 확인해주세요.(env 파일 추가 필수입니다.)⭐️
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인