### PR TITLE
feat: 차량 경로 조회 가능 기간 수정

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
@@ -20,9 +20,15 @@ public interface MyBatisVehicleInfoMapper {
 			select
 				vi.vehicle_id as vehicleId,
 					vi.vehicle_number as vehicleNumber,
-				vi.created_at as firstDateAt,
 				(
-					select ci.created_at
+					select ci.interval_at
+					from cycle_info ci
+					where ci.vehicle_id = vi.vehicle_id
+					order by ci.interval_at ASC
+					limit 1
+				) as firstDateAt,
+				(
+					select ci.interval_at
 					from cycle_info ci
 					where ci.vehicle_id = vi.vehicle_id
 					order by ci.interval_at DESC

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleInfoResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleInfoResponse.java
@@ -1,14 +1,38 @@
 package org.controlcenter.vehicle.presentation.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.LocalDateTime;
 
+import java.time.format.DateTimeFormatter;
+
 import lombok.Builder;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 @Builder
+@Slf4j
 public record VehicleInfoResponse(
 	Long vehicleId,
 	String vehicleNumber,
-	LocalDateTime firstDateAt,
-	LocalDateTime lastDateAt
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime firstDateAt,
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime lastDateAt
 ) {
+	public VehicleInfoResponse(Long vehicleId, String vehicleNumber,
+		LocalDateTime firstDateAt,
+		LocalDateTime lastDateAt) {
+		this.vehicleId = vehicleId;
+		this.vehicleNumber = vehicleNumber;
+		this.firstDateAt = normalizeToMinute(firstDateAt);
+		this.lastDateAt = roundUpToNextMinute(lastDateAt);
+	}
+
+	private static LocalDateTime normalizeToMinute(LocalDateTime dateTime) {
+		return dateTime.withSecond(0);
+	}
+
+	private static LocalDateTime roundUpToNextMinute(LocalDateTime dateTime) {
+		return dateTime.getSecond() == 0 ?
+			dateTime : dateTime.plusMinutes(1).withSecond(0);
+	}
 }

--- a/monicar-control-center/src/main/resources/application-dev.yml
+++ b/monicar-control-center/src/main/resources/application-dev.yml
@@ -48,3 +48,7 @@ cors:
 
 cookie:
   domain: ${COOKIE_DOMAIN}
+
+logging:
+  file:
+    path: ${user.dir}/logs

--- a/monicar-control-center/src/main/resources/application-prod.yml
+++ b/monicar-control-center/src/main/resources/application-prod.yml
@@ -48,3 +48,7 @@ cors:
 
 cookie:
   domain: ${COOKIE_DOMAIN}
+
+logging:
+  file:
+    path: /var/log/app-logs

--- a/monicar-control-center/src/main/resources/logback-spring.xml
+++ b/monicar-control-center/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <configuration>
 
     <springProperty name="LOG_PATH" source="logging.file.path"/>
-    <property name="SERVER_NAME" value="${server.name:-emulator}" />
+    <property name="SERVER_NAME" value="${server.name:-control-center}" />
 
     <!-- 콘솔 출력 Appender -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/monicar-control-center/src/test/resources/application-test.yml
+++ b/monicar-control-center/src/test/resources/application-test.yml
@@ -37,3 +37,6 @@ jwt:
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+
+cookie:
+  domain: ${COOKIE_DOMAIN}


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

1. 관제에도 logback 적용했습니다.
2. 차량 경로 조회 기간을 수정했습니다. 가장 오래된 위치의 연월일시분초 에서 초를 내림하였고, 가장 최신 위치의 연월일시분초 에서 초를 올림하였습니다 ! 유저가 초까지 사용하지는 않는다는 것을 확인하고, 몇 초정도의 여유 시간을 준겁니다.

## #️⃣ 연관된 이슈

#255 

## 💡 리뷰어에게 하고 싶은 말

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인