### PR TITLE
fix: 로그백 설정 파일 이름을 변경하고 yml 파일에 명시, timezone 설정

### DIFF
--- a/monicar-control-center/src/main/resources/application-dev.yml
+++ b/monicar-control-center/src/main/resources/application-dev.yml
@@ -52,5 +52,6 @@ cookie:
   domain: ${COOKIE_DOMAIN}
 
 logging:
+  config: classpath:logback-spring-dev.xml
   file:
     path: ${user.dir}/logs

--- a/monicar-control-center/src/main/resources/application-prod.yml
+++ b/monicar-control-center/src/main/resources/application-prod.yml
@@ -52,5 +52,6 @@ cookie:
   domain: ${COOKIE_DOMAIN}
 
 logging:
+  config: classpath:logback-spring-dev.xml
   file:
     path: /var/log/app-logs

--- a/monicar-control-center/src/main/resources/logback-spring-dev.xml
+++ b/monicar-control-center/src/main/resources/logback-spring-dev.xml
@@ -6,7 +6,9 @@
     <!-- 콘솔 출력 Appender -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger{36}) - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss, Asia/Seoul} [%thread] %highlight(%-5level)
+                %cyan(%logger{36}) - %msg%n
+            </pattern>
         </layout>
     </appender>
 
@@ -25,7 +27,10 @@
 
         <!-- 로그 출력 포맷 -->
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss, Asia/Seoul}:%-3relative][%thread] %-5level
+                %logger{36}
+                - %msg%n
+            </pattern>
         </encoder>
     </appender>
 

--- a/monicar-emulator/src/main/resources/application.yml
+++ b/monicar-emulator/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
     name: monicar-emulator
 
 logging:
+  config: classpath:logback-spring-dev.xml
   file:
     path: ${user.dir}/logs
 

--- a/monicar-emulator/src/main/resources/logback-spring-dev.xml
+++ b/monicar-emulator/src/main/resources/logback-spring-dev.xml
@@ -6,7 +6,9 @@
     <!-- 콘솔 출력 Appender -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger{36}) - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss, Asia/Seoul} [%thread] %highlight(%-5level)
+                %cyan(%logger{36}) - %msg%n
+            </pattern>
         </layout>
     </appender>
 
@@ -25,7 +27,9 @@
 
         <!-- 로그 출력 포맷 -->
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss, Asia/Seoul}:%-3relative][%thread] %-5level
+                %logger{36} - %msg%n
+            </pattern>
         </encoder>
     </appender>
 

--- a/monicar-event-hub/src/main/resources/application-dev.yml
+++ b/monicar-event-hub/src/main/resources/application-dev.yml
@@ -29,6 +29,7 @@ spring:
       ddl-auto: none
 
 logging:
+  config: classpath:logback-spring-dev.xml
   file:
     path: ${user.dir}/logs
 

--- a/monicar-event-hub/src/main/resources/logback-spring-dev.xml
+++ b/monicar-event-hub/src/main/resources/logback-spring-dev.xml
@@ -6,7 +6,8 @@
     <!-- 콘솔 출력 Appender -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger{36}) - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss, Asia/Seoul} [%thread] %highlight(%-5level) %cyan(%logger{36}) - %msg%n
+            </pattern>
         </layout>
     </appender>
 
@@ -25,7 +26,7 @@
 
         <!-- 로그 출력 포맷 -->
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss, Asia/Seoul}:%-3relative][%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

오늘 크로스 테스트 중 발견한 로그백 관련 문제를 해결했습니다

## #️⃣ 연관된 이슈

#261 
⬇️ 이슈 내용
- 로컬에서 모듈 안에 LOG_PATH_NOT_DEFINED 이름의 로그 파일 디렉토리가 생기는 문제
- 운영에 저장된 로그 파일에 찍힌 timestamp가 한국시간이 아닌 문제

## 💡 리뷰어에게 하고 싶은 말

- 이슈 내용 1번
  - 원인: 스프링 부트가 설정 파일들을 읽을 때 application-dev.yml파일보다 로그백 설정 파일인 logback-spring.xml을 먼저 읽어버리는 것이 원인이었습니다. ( 로깅 시스템이 가장 먼저 세팅되어야 하다보니 spring boot 자체적으로 로깅 관련 파일을 먼저 찾는다고 합니다 ) xml을 먼저 읽어버리면 로그 파일의 경로를 제대로 설정하지 못합니다. **source="logging.file.path"** 이 값은 yml에 있으니까요! ! !
  
  - 해결 방법:  logback-spring.xml을 logback-spring-dev.xml로 바꾸고, yml에 해당 파일을 명시하면 **로깅 관련 xml을 찾지 못함 -> yml을 먼저 읽게 됨 -> 어? 읽어야하는 xml이 있네 -> xml 읽음** 의 순서로 작동하여 로그 파일의 경로도 올바르게 설정됩니다.

- 이슈 내용 2번 
  - 해결 방법: logback.xml 파일 안에 timezone(Asia/Seoul)을 명시했습니다.

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인