### PR TITLE
fix: 기존 PageResponse를 포함하여 반환하도록 수정

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/common/response/PageResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/response/PageResponse.java
@@ -3,6 +3,7 @@ package org.controlcenter.common.response;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import lombok.Getter;
 
@@ -24,5 +25,15 @@ public class PageResponse<T> {
 		this.totalPages = page.getTotalPages();
 		this.first = page.isFirst();
 		this.last = page.isLast();
+	}
+
+	public PageResponse(List<T> content, Pageable pageable, long totalElements) {
+		this.content = content;
+		this.page = pageable.getPageNumber() + 1;
+		this.size = pageable.getPageSize();
+		this.totalElements = totalElements;
+		this.totalPages = (int) Math.ceil((double) totalElements / this.size);
+		this.first = this.page == 1;
+		this.last = this.page >= this.totalPages;
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
@@ -9,6 +9,9 @@ import org.controlcenter.vehicle.presentation.dto.VehicleEngineStatusResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleInfoResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleInfoSearchRequest;
 import org.controlcenter.vehicle.presentation.dto.VehicleModalResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -36,23 +39,25 @@ public class VehicleQueryRepository {
 		);
 	}
 
-	public List<RouteResponse> getVehicleRouteFromWithPagination(
+	public Page<RouteResponse> getVehicleRouteFromWithPagination(
 		Long vehicleId,
 		LocalDateTime startTime,
 		LocalDateTime endTime,
 		Integer interval,
-		Integer page,
-		Integer size
+		Pageable pageable
 	) {
-		int offset = page * size;
-		return myBatisVehicleInfoMapper.getVehicleRouteFromWithPagination(
-			vehicleId,
-			startTime,
-			endTime,
-			interval,
-			size,
-			offset
+		int size = pageable.getPageSize();
+		int offset = (int) pageable.getOffset();
+
+		List<RouteResponse> routes = myBatisVehicleInfoMapper.getVehicleRouteFromWithPagination(
+			vehicleId, startTime, endTime, interval, size, offset
 		);
+
+		int totalElements = myBatisVehicleInfoMapper.countVehicleRoutes(
+			vehicleId, startTime, endTime, interval
+		);
+
+		return new PageImpl<>(routes, pageable, totalElements);
 	}
 
 	public VehicleModalResponse.RecentVehicleInfo getRecentVehicleInfo(Long vehicleId) {

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
@@ -101,6 +101,29 @@ public interface MyBatisVehicleInfoMapper {
 		@Param("offset") Integer offset
 	);
 
+	/**
+	 * 1억개 데이터 기준
+	 * 멀티 컬럼 인덱스 : (vehicle_id, interval_at) 적용
+	 * 전체 데이터 개수 조회
+	 */
+	@Select("""
+		SELECT COUNT(*) 
+		FROM (
+			SELECT ROW_NUMBER() OVER (ORDER BY interval_at) AS row_num
+			FROM cycle_info
+			WHERE vehicle_id = #{vehicleId}
+			  AND #{startTime} <= interval_at
+			  AND interval_at <= #{endTime}
+		) AS filtered_data
+		WHERE (row_num - 1) % #{interval} = 0
+	""")
+	int countVehicleRoutes(
+		@Param("vehicleId") Long vehicleId,
+		@Param("startTime") LocalDateTime startTime,
+		@Param("endTime") LocalDateTime endTime,
+		@Param("interval") Integer interval
+	);
+
 
 	@Select("""
 			select

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/swagger/VehicleApi.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/swagger/VehicleApi.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.controlcenter.common.response.BaseResponse;
+import org.controlcenter.common.response.PageResponse;
 import org.controlcenter.vehicle.domain.VehicleInformation;
 import org.controlcenter.vehicle.presentation.dto.GeoClusteringResponse;
 import org.controlcenter.vehicle.presentation.dto.GeoCoordinateDetailsResponse;
@@ -14,6 +15,8 @@ import org.controlcenter.vehicle.presentation.dto.VehicleLocationResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleModalResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleRegisterRequest;
 import org.controlcenter.vehicle.presentation.dto.VehicleRouteResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -83,13 +86,12 @@ public interface VehicleApi {
 	@Operation(
 		summary = "개별 차량 경로 페이징 조회",
 		description = "차량 고유 ID를 통해 특정 시간 안에 일정한 간격의 경로 정보를 페이지네이션으로 조회")
-	BaseResponse<VehicleRouteResponse> getVehicleRouteWithPagination(
+	BaseResponse<PageResponse<VehicleRouteResponse>> getVehicleRouteWithPagination(
 		@PathVariable("vehicle-id") Long vehicleId,
 		@RequestParam(value = "startTime") LocalDateTime startTime,
 		@RequestParam(value = "endTime") LocalDateTime endTime,
 		@RequestParam(value = "interval", defaultValue = "60") Integer interval,
-		@RequestParam(value = "page", defaultValue = "0") Integer page,
-		@RequestParam(value = "size", defaultValue = "5") Integer size
+		@PageableDefault(size = 5) Pageable pageable
 	);
 
 }


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

기존 PageResponse를 포함하여 반환하도록 수정

## #️⃣ 연관된 이슈

#269 

## 💡 리뷰어에게 하고 싶은 말

- 경로조회시, PageResponse정보를 포함하기 위해 기존 `getVehicleRouteFromWithPagination`메소드에서 데이터 전체의 개수를 조회하는 로직을 추가하였습니다. 
- 또한, `getVehicleRouteFromWithPagination`의 반환타입을 Page<RouteResponse>로 수정하였습니다.

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인