### PR TITLE
fix: 실시간용 개별 차량 정보 조회 기능 수정

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.controlcenter.vehicle.infrastructure.mybatis.MyBatisVehicleInfoMapper;
+import org.controlcenter.vehicle.presentation.RouteResponseWithStatus;
 import org.controlcenter.vehicle.presentation.dto.RouteResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleEngineStatusResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleInfoResponse;
@@ -60,7 +61,7 @@ public class VehicleQueryRepository {
 		return new PageImpl<>(routes, pageable, totalElements);
 	}
 
-	public List<RouteResponse> getRecentRoutesByVehicle(Long vehicleId, LocalDateTime currentTime) {
+	public List<RouteResponseWithStatus> getRecentRoutesByVehicle(Long vehicleId, LocalDateTime currentTime) {
 		return myBatisVehicleInfoMapper.getRecentRoutesByVehicle(
 			vehicleId,
 			currentTime

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
@@ -8,6 +8,7 @@ import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import org.controlcenter.vehicle.infrastructure.mybatis.dto.GeoCoordinateDetailsDto;
 import org.controlcenter.vehicle.infrastructure.mybatis.dto.GeoCoordinateDto;
+import org.controlcenter.vehicle.presentation.RouteResponseWithStatus;
 import org.controlcenter.vehicle.presentation.dto.RouteResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleEngineStatusResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleInfoResponse;
@@ -124,20 +125,22 @@ public interface MyBatisVehicleInfoMapper {
 		@Param("interval") Integer interval
 	);
 
-
 	@Select("""
-		select
-		  lat,
-		  lng,
-		  spd,
-		  interval_at
-		from cycle_info
-		where vehicle_id = #{vehicleId}
-			and interval_at <= #{currentTime}
-  		order by interval_at desc
-  		limit 60;
+		SELECT
+		  ci.lat,
+		  ci.lng,
+		  ci.spd,
+		  vi.status,
+		  ci.interval_at
+  		FROM cycle_info ci
+           JOIN vehicle_information vi ON ci.vehicle_id = vi.vehicle_id
+  		WHERE ci.vehicle_id = #{vehicleId}
+    		AND vi.status = 'IN_OPERATION'
+    		AND ci.interval_at <= DATE_SUB(#{currentTime}, INTERVAL 2 MINUTE)
+      	ORDER BY ci.interval_at DESC
+       	LIMIT 65;
 		""")
-	List<RouteResponse> getRecentRoutesByVehicle(
+	List<RouteResponseWithStatus> getRecentRoutesByVehicle(
 		@Param("vehicleId") Long vehicleId,
 		@Param("currentTime") LocalDateTime currentTime
 	);

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/RouteResponseWithStatus.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/RouteResponseWithStatus.java
@@ -1,0 +1,16 @@
+package org.controlcenter.vehicle.presentation;
+
+import org.controlcenter.vehicle.domain.VehicleStatus;
+
+import java.time.LocalDateTime;
+
+public record RouteResponseWithStatus(
+	Integer lat,
+	Integer lng,
+	Integer spd,
+	VehicleStatus status,
+	LocalDateTime timestamp
+) {
+}
+
+

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
@@ -24,6 +24,7 @@ import org.controlcenter.vehicle.presentation.dto.VehicleLocationResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleModalResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleRegisterRequest;
 import org.controlcenter.vehicle.presentation.dto.VehicleRouteResponse;
+import org.controlcenter.vehicle.presentation.dto.VehicleRouteWithStatusResponse;
 import org.controlcenter.vehicle.presentation.swagger.VehicleApi;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -170,20 +171,19 @@ public class VehicleController implements VehicleApi {
 		return BaseResponse.success(pageResponse);
 	}
 
-
 	/**
 	 * (실시간 용) 개별 차량 경로 조회 API
 	 */
 	@GetMapping("/{vehicle-id}/recent/routes")
-	public BaseResponse<VehicleRouteResponse> getRecentRoutesByVehicle(
+	public BaseResponse<VehicleRouteWithStatusResponse> getRecentRoutesByVehicle(
 		@PathVariable("vehicle-id") Long vehicleId,
 		@RequestParam(value = "currentTime") LocalDateTime currentTime
 	) {
 		String vehicleNumber = vehicleService.getVehicleNumber(vehicleId);
 
-		List<RouteResponse> routesResponses = vehicleQueryRepository.getRecentRoutesByVehicle(vehicleId, currentTime);
+		List<RouteResponseWithStatus> routesResponses = vehicleQueryRepository.getRecentRoutesByVehicle(vehicleId, currentTime);
 
-		VehicleRouteResponse response = VehicleRouteResponse.builder()
+		VehicleRouteWithStatusResponse response = VehicleRouteWithStatusResponse.builder()
 			.vehicleNumber(vehicleNumber)
 			.routes(routesResponses)
 			.build();

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleRouteWithStatusResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleRouteWithStatusResponse.java
@@ -1,0 +1,14 @@
+package org.controlcenter.vehicle.presentation.dto;
+
+import lombok.Builder;
+
+import org.controlcenter.vehicle.presentation.RouteResponseWithStatus;
+
+import java.util.List;
+
+@Builder
+public record VehicleRouteWithStatusResponse(
+	String vehicleNumber,
+	List<RouteResponseWithStatus> routes
+) {
+}

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/swagger/VehicleApi.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/swagger/VehicleApi.java
@@ -15,6 +15,7 @@ import org.controlcenter.vehicle.presentation.dto.VehicleLocationResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleModalResponse;
 import org.controlcenter.vehicle.presentation.dto.VehicleRegisterRequest;
 import org.controlcenter.vehicle.presentation.dto.VehicleRouteResponse;
+import org.controlcenter.vehicle.presentation.dto.VehicleRouteWithStatusResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -62,8 +63,8 @@ public interface VehicleApi {
 		@RequestParam(value = "interval", defaultValue = "60") Integer interval
 	);
 
-	@Operation(summary = "실시간용 개별 차량 경로 조회", description = "차량 고유 ID를 통해 특정 시간 기준 최근 60개 경로 정보를 조회")
-	BaseResponse<VehicleRouteResponse> getRecentRoutesByVehicle(
+	@Operation(summary = "실시간용 개별 차량 경로 조회", description = "차량 고유 ID를 통해 특정 시간 기준 2분전 최근 65개 경로 정보를 조회")
+	BaseResponse<VehicleRouteWithStatusResponse> getRecentRoutesByVehicle(
 		@PathVariable("vehicle-id") Long vehicleId,
 		@RequestParam(value = "currentTime") LocalDateTime currentTime
 	);


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

실시간용 개별 차량 정보 조회 기능을 수정했습니다.

## #️⃣ 연관된 이슈

#274 

## 💡 리뷰어에게 하고 싶은 말

- 프론트 측 요청에 따라 기존 요청시간 기준 60개가 아닌 요청시간 - 2분기준 65개 데이터를 리스트로 응답하도록 수정했습니다.

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인