### PR TITLE
fix: 차량 상세 조회 시 상태값 추가

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/DrivingLogService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/application/DrivingLogService.java
@@ -80,9 +80,10 @@ public class DrivingLogService {
 			drivingLogRepository.sumByVehicleIdAndDateRange(vehicleId, startDate, endDate.plusDays(1))
 		).orElse(0);
 
-		SpecificVehicleInformation vehicleType = SpecificVehicleInformation.builder()
+		SpecificVehicleInformation vehicleInfo = SpecificVehicleInformation.builder()
 			.vehicleNumber(header.getVehicleNumber())
 			.vehicleModel(header.getVehicleTypesName())
+			.status(header.getStatus())
 			.build();
 
 		BusinessInfo businessInfo = BusinessInfo.builder()
@@ -99,7 +100,7 @@ public class DrivingLogService {
 			.taxStartPeriod(startDate)
 			.taxEndPeriod(endDate)
 			.businessInfo(businessInfo)
-			.vehicleType(vehicleType)
+			.vehicleInfo(vehicleInfo)
 			.records(drivingLogsPage)
 			.taxPeriodDistance(sumDistance)
 			.taxPeriodBusinessDistance(summary.getCommuteCount())

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/SpecificVehicleInformation.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/SpecificVehicleInformation.java
@@ -10,10 +10,12 @@ import lombok.Getter;
 public class SpecificVehicleInformation {
 	private String vehicleNumber;
 	private String vehicleModel;
+	private VehicleStatus status;
 
 	@QueryProjection
-	public SpecificVehicleInformation(String vehicleNumber, String vehicleModel) {
+	public SpecificVehicleInformation(String vehicleNumber, String vehicleModel, VehicleStatus status) {
 		this.vehicleNumber = vehicleNumber;
 		this.vehicleModel = vehicleModel;
+		this.status = status;
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleHeaderInfo.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleHeaderInfo.java
@@ -14,15 +14,17 @@ public class VehicleHeaderInfo {
 	private Long companyId;
 	private String companyName;
 	private String businessRegistrationNumber;
+	private VehicleStatus status;
 
 	@QueryProjection
 	public VehicleHeaderInfo(Long vehicleId, String vehicleNumber, String vehicleTypesName, Long companyId,
-		String companyName, String businessRegistrationNumber) {
+		String companyName, String businessRegistrationNumber, VehicleStatus status) {
 		this.vehicleId = vehicleId;
 		this.vehicleNumber = vehicleNumber;
 		this.vehicleTypesName = vehicleTypesName;
 		this.companyId = companyId;
 		this.companyName = companyName;
 		this.businessRegistrationNumber = businessRegistrationNumber;
+		this.status = status;
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/DrivingLogJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/DrivingLogJpaRepository.java
@@ -177,7 +177,8 @@ public class DrivingLogJpaRepository implements DrivingLogRepository {
 				vehicleTypeEntity.vehicleTypesName,
 				companyEntity.id,
 				companyEntity.companyName,
-				companyEntity.businessRegistrationNumber
+				companyEntity.businessRegistrationNumber,
+				vehicleInformationEntity.status
 			))
 			.from(vehicleInformationEntity)
 			.join(vehicleTypeEntity).on(vehicleInformationEntity.vehicleTypeId.eq(vehicleTypeEntity.id))

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/DrivingLogResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/DrivingLogResponse.java
@@ -13,7 +13,7 @@ public record DrivingLogResponse(
 	String vehicleModel,
 	Integer drivingDays,
 	Integer totalDistance,
-	String status
+	VehicleStatus status
 ) {
 	public static DrivingLogResponse from(DrivingLog drivingLog) {
 		return DrivingLogResponse.builder()
@@ -22,7 +22,7 @@ public record DrivingLogResponse(
 			.vehicleModel(drivingLog.getVehicleModel())
 			.drivingDays(drivingLog.getDrivingDays())
 			.totalDistance(drivingLog.getTotalDistance())
-			.status(drivingLog.getStatus().getLabel())
+			.status(drivingLog.getStatus())
 			.build();
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleDrivingLogDetailsResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleDrivingLogDetailsResponse.java
@@ -3,11 +3,11 @@ package org.controlcenter.vehicle.presentation.dto;
 import java.time.LocalDate;
 import java.util.List;
 
-import lombok.Builder;
-
 import org.controlcenter.vehicle.domain.BusinessInfo;
 import org.controlcenter.vehicle.domain.DrivingLogDetailsContent;
 import org.controlcenter.vehicle.domain.SpecificVehicleInformation;
+
+import lombok.Builder;
 
 @Builder
 public record VehicleDrivingLogDetailsResponse(
@@ -17,7 +17,7 @@ public record VehicleDrivingLogDetailsResponse(
 	int taxPeriodDistance,
 	int taxPeriodBusinessDistance,
 	int businessUseRatio,
-	SpecificVehicleInformation vehicleType,
+	SpecificVehicleInformation vehicleInfo,
 	List<DrivingLogDetailsContent> records
 ) {
 }


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- 차량 상세 조회 시 상태값 추가(운행중인 상태일 때는 삭제버튼 숨기기 위함)
- 차량 리스트 조회 시 상태값 문자열 대신 상수명 그대로 전달
<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#286
<!-- ex) #이슈번호, #이슈번호 -->

## 💡 리뷰어에게 하고 싶은 말
- 차량 상태 enum 상수명 그대로 전달하여 프론트엔드에서 변환하도록 통일하였습니다.
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인