### PR TITLE
chore: 스웨거 외부 설정을 통한 서버 URL 동적 구성

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/config/SwaggerConfig.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/config/SwaggerConfig.java
@@ -1,24 +1,53 @@
 package org.controlcenter.config;
 
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
 public class SwaggerConfig {
+	@Value("${swagger.server.prod-url}")
+	private String prodUrl;
+
+	@Value("${swagger.server.dev-url}")
+	private String devUrl;
 
 	@Bean
-	public OpenAPI openAPI() {
-		return new OpenAPI()
-			.info(apiInfo());
-	}
-
-	private Info apiInfo() {
-		return new Info()
+	public OpenAPI openAPI(Environment env) {
+		Info info = new Info()
 			.title("Monicar API")
 			.description("API")
 			.version("1.0.0");
+
+		return new OpenAPI()
+			.info(info)
+			.servers(getServers(env));
+	}
+
+	private List<Server> getServers(Environment env) {
+		if (Arrays.asList(env.getActiveProfiles()).contains("prod")) {
+			return List.of(
+				new Server()
+					.url(prodUrl)
+					.description("개발 서버")
+			);
+		} else {
+			return List.of(
+				new Server()
+					.url(devUrl)
+					.description("로컬 서버"),
+				new Server()
+					.url(prodUrl)
+					.description("개발 서버")
+			);
+		}
 	}
 }

--- a/monicar-control-center/src/main/resources/application-dev.yml
+++ b/monicar-control-center/src/main/resources/application-dev.yml
@@ -55,3 +55,7 @@ logging:
   config: classpath:logback-spring-dev.xml
   file:
     path: ${user.dir}/logs
+swagger:
+  server:
+    prod-url: ${DEV_URL}
+    dev-url: ${PROD_URL}

--- a/monicar-control-center/src/main/resources/application-prod.yml
+++ b/monicar-control-center/src/main/resources/application-prod.yml
@@ -55,3 +55,7 @@ logging:
   config: classpath:logback-spring-dev.xml
   file:
     path: /var/log/app-logs
+swagger:
+  server:
+    prod-url: ${DEV_URL}
+    dev-url: ${PROD_URL}


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- SwaggerConfig에서 @Value를 사용하여 prod/dev 서버 URL을 외부 설정에서 주입받도록 변경
- 활성 프로파일(prod 여부)에 따라 적절한 서버 URL을 설정하도록 getServers 메서드 리팩토링
- 하드코딩된 URL 제거로 환경별 유연한 관리 가능

<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#288 

<!-- ex) #이슈번호, #이슈번호 -->

## 💡 리뷰어에게 하고 싶은 말
- 개발서버 스웨거에서 https가 아닌 http로 요청이 되어 수정하였습니다.
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인