### PR TITLE
feat: 차량 정보의 상태(운행, 미운행) update 로직

### DIFF
--- a/monicar-control-center/src/test/resources/application-test.yml
+++ b/monicar-control-center/src/test/resources/application-test.yml
@@ -40,3 +40,8 @@ cors:
 
 cookie:
   domain: ${COOKIE_DOMAIN}
+
+swagger:
+  server:
+    prod-url: ${PROD_URL}
+    dev-url: ${DEV_URL}

--- a/monicar-event-hub/src/main/java/org/eventhub/application/VehicleService.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/application/VehicleService.java
@@ -5,6 +5,7 @@ import org.eventhub.common.exception.BusinessException;
 import org.eventhub.common.response.ErrorCode;
 import org.eventhub.domain.VehicleInformation;
 import org.eventhub.domain.UpdateTotalDistance;
+import org.eventhub.domain.VehicleStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +30,12 @@ public class VehicleService {
 
 	}
 
+	@Transactional
+	public VehicleStatus updateVehicleStatus(Long vehicleId, VehicleStatus status) {
+		return vehicleRepository.updateVehicleStatus(vehicleId, status);
+	}
+
+	@Transactional
 	public Long updateTotalDistance(UpdateTotalDistance updateTotalDistanceDto) {
 		return vehicleRepository.updateTotalDistance(updateTotalDistanceDto);
 	}

--- a/monicar-event-hub/src/main/java/org/eventhub/application/port/VehicleRepository.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/application/port/VehicleRepository.java
@@ -4,11 +4,14 @@ import java.util.Optional;
 
 import org.eventhub.domain.VehicleInformation;
 import org.eventhub.domain.UpdateTotalDistance;
+import org.eventhub.domain.VehicleStatus;
 
 public interface VehicleRepository {
 	Optional<VehicleInformation> findById(Long vehicleId);
 	Optional<VehicleInformation> findByMdn(Long mdn);
 	Long updateTotalDistance(UpdateTotalDistance updateTotalDistanceDto);
+
+	VehicleStatus updateVehicleStatus(Long vehicleId, VehicleStatus vehicleStatus);
 
 	void updateDrivingDaysAll();
 }

--- a/monicar-event-hub/src/main/java/org/eventhub/infrastructure/repository/VehicleInformationRepositoryAdapter.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/infrastructure/repository/VehicleInformationRepositoryAdapter.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.eventhub.application.port.VehicleRepository;
 import org.eventhub.domain.VehicleInformation;
 import org.eventhub.domain.UpdateTotalDistance;
+import org.eventhub.domain.VehicleStatus;
 import org.eventhub.infrastructure.repository.jpa.entity.QVehicleInformationEntity;
 import org.eventhub.infrastructure.repository.jpa.entity.VehicleInformationEntity;
 import org.eventhub.infrastructure.repository.jpa.VehicleInformationJpaRepository;
@@ -33,6 +34,21 @@ public class VehicleInformationRepositoryAdapter implements VehicleRepository {
 	public Optional<VehicleInformation> findByMdn(Long mdn) {
 		return vehicleInformationJpaRepository.findByMdn(mdn)
 			.map(VehicleInformationEntity::toDomain);
+	}
+
+	@Override
+	public VehicleStatus updateVehicleStatus(Long vehicleId, VehicleStatus vehicleStatus) {
+		QVehicleInformationEntity vehicleInfo = QVehicleInformationEntity.vehicleInformationEntity;
+
+		jpaQueryFactory.update(vehicleInfo)
+			.set(vehicleInfo.status, vehicleStatus)
+			.where(vehicleInfo.id.eq(vehicleId))
+			.execute();
+
+		return jpaQueryFactory.select(vehicleInfo.status)
+			.from(vehicleInfo)
+			.where(vehicleInfo.id.eq(vehicleId))
+			.fetchOne();
 	}
 
 	@Override

--- a/monicar-event-hub/src/main/java/org/eventhub/infrastructure/repository/jpa/entity/VehicleInformationEntity.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/infrastructure/repository/jpa/entity/VehicleInformationEntity.java
@@ -3,7 +3,11 @@ package org.eventhub.infrastructure.repository.jpa.entity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
 import org.eventhub.domain.VehicleInformation;
+import org.eventhub.domain.VehicleStatus;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -45,6 +49,9 @@ public class VehicleInformationEntity {
 	private Integer drivingDays;
 
 	private Long sum;
+
+	@Enumerated(value = EnumType.STRING)
+	private VehicleStatus status;
 
 	private LocalDate deliveryDate;
 

--- a/monicar-event-hub/src/main/java/org/eventhub/presentation/OnOffController.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/presentation/OnOffController.java
@@ -14,6 +14,7 @@ import org.eventhub.domain.VehicleEventType;
 import org.eventhub.domain.VehicleInformation;
 import org.eventhub.domain.VehicleOffEventCreate;
 import org.eventhub.domain.VehicleOnEventCreate;
+import org.eventhub.domain.VehicleStatus;
 import org.eventhub.presentation.request.KeyOffRequest;
 import org.eventhub.presentation.request.KeyOnRequest;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,6 +53,8 @@ public class OnOffController {
 		VehicleOnEventCreate vehicleOnEventCreate = request.toDomain(vehicleInformation.getId(), vehicleInformation.getSum());
 		vehicleEventService.saveVehicleEvent(vehicleOnEventCreate);
 
+		vehicleService.updateVehicleStatus(vehicleInformation.getId(), VehicleStatus.IN_OPERATION);
+
 		return BaseResponse.success();
 	}
 
@@ -70,6 +73,8 @@ public class OnOffController {
 		if (isAlreadyOff) {
 			return BaseResponse.fail(ErrorCode.WRONG_APPROACH);
 		}
+
+		vehicleService.updateVehicleStatus(vehicleInformation.getId(), VehicleStatus.NOT_DRIVEN);
 
 		Long updatedTotalDistance = vehicleService.updateTotalDistance(UpdateTotalDistance.of(
 			vehicleInformation.getId(), request.sum()


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

on 요청시 vehicle_information의 status를 IN_OPERATION으로,
off 요청시 vehicle_information의 status를 NOT_DRIVEN으로 변경합니다.

## #️⃣ 연관된 이슈

#278 

## 💡 리뷰어에게 하고 싶은 말

test.yml에도 환경 변수를 추가해서 로컬 빌드 테스트시 에러나지 않도록 했습니다.
⭐️ BE Page 마지막에 있는 local용 env.properties를 main/resource/env.properties 와 test/resource/env.properties에 추가해주세요.

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인