### PR TITLE
fix: mdn컬럼에 unique속성 추가

### DIFF
--- a/monicar-collector/src/main/java/org/collector/domain/VehicleInformation.java
+++ b/monicar-collector/src/main/java/org/collector/domain/VehicleInformation.java
@@ -42,12 +42,11 @@ public class VehicleInformation implements Serializable {
 	@ManyToOne
 	@JoinColumn(name = "company_id")
 	private Company company;
-
 	@ManyToOne
 	@JoinColumn(name = "vehicle_type_id")
 	private VehicleType vehicleType;
-
 	private String vehicleNumber;
+	@Column(unique = true)
 	private Long mdn;
 	private String tid;
 	private Long mid;

--- a/monicar-control-center/src/main/resources/schema/init-schema.sql
+++ b/monicar-control-center/src/main/resources/schema/init-schema.sql
@@ -85,7 +85,9 @@ CREATE TABLE vehicle_information
     `delivery_date`   DATE         NOT NULL COMMENT '출고일자',
     `created_at`      TIMESTAMP    NOT NULL COMMENT '테이블 생성 시간',
     `updated_at`      TIMESTAMP    NOT NULL COMMENT '테이블 수정 시간',
-    `deleted_at`      TIMESTAMP    NULL COMMENT '테이블 삭제 시간'
+    `deleted_at`      TIMESTAMP    NULL COMMENT '테이블 삭제 시간',
+    constraint mdn
+        unique (mdn)
 ) ENGINE = InnoDB COMMENT ='차량정보';
 
 CREATE TABLE vehicle_types


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

mdn컬럼에 unique속성 추가

## #️⃣ 연관된 이슈

#297 

## 💡 리뷰어에게 하고 싶은 말

- 차량정보 테이블의 mdn컬럼에 unqiue속성 추가하였습니다. Control-Center 모듈은 entity상에서 jpa관련 어노테이션 사용하지 않는 것 같아 추가하지 않았습니다. (다른 모듈도 마찬가지) 
- 차량정보 테이블의 `vehicle_number` 컬럼도 unqiue속성이 추가되어야할 것 같은데, 관제쪽에 이 속성을 추가함으로써 관제 코드쪽에 영향이 될 것 같습니다.
- 따라서, 이 부분은 @kbyunghoon 님이 추가하는게 좋을 듯해요! 

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인