### PR TITLE
feat: 주기 정보에서 안쓰이는 sum 지우기

### DIFF
--- a/monicar-emulator/src/main/java/org/emulator/sensor/GpsTracker.java
+++ b/monicar-emulator/src/main/java/org/emulator/sensor/GpsTracker.java
@@ -81,12 +81,12 @@ public class GpsTracker implements SensorTracker {
 	}
 
 	private boolean isReadyToSendCycleInfo(int time) {
-		return cycleInfos.size() > time;
+		return (!cycleInfos.isEmpty()) && (cycleInfos.size() > time);
 	}
 
 	private List<CycleInfo> pollFromDeque(int size) {
 		List<CycleInfo> result = new ArrayList<>();
-		while (!cycleInfos.isEmpty() && result.size() < size) {
+		while (result.size() < size) {
 			CycleInfo cycleInfo = cycleInfos.pollFirst();
 			if (Objects.nonNull(cycleInfo)) {
 				result.add(cycleInfo);

--- a/monicar-emulator/src/main/java/org/emulator/sensor/GpsTracker.java
+++ b/monicar-emulator/src/main/java/org/emulator/sensor/GpsTracker.java
@@ -81,7 +81,7 @@ public class GpsTracker implements SensorTracker {
 	}
 
 	private boolean isReadyToSendCycleInfo(int time) {
-		return (!cycleInfos.isEmpty()) && (cycleInfos.size() > time);
+		return (!cycleInfos.isEmpty()) && (cycleInfos.size() >= time);
 	}
 
 	private List<CycleInfo> pollFromDeque(int size) {

--- a/monicar-event-hub/src/main/java/org/eventhub/domain/CycleInfo.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/domain/CycleInfo.java
@@ -14,5 +14,4 @@ public class CycleInfo {
 	private long lng;
 	private int ang;
 	private int spd;
-	private int sum;
 }

--- a/monicar-event-hub/src/main/java/org/eventhub/infrastructure/messaging/command/CycleInfoCommand.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/infrastructure/messaging/command/CycleInfoCommand.java
@@ -16,8 +16,7 @@ public record CycleInfoCommand(
 	Long lat,
 	Long lng,
 	Integer ang,
-	Integer spd,
-	Integer sum
+	Integer spd
 ) {
 	public static CycleInfoCommand from(CycleInfo cycleInfo) {
 		return CycleInfoCommand.builder()
@@ -27,7 +26,6 @@ public record CycleInfoCommand(
 			.lng(cycleInfo.getLng())
 			.ang(cycleInfo.getAng())
 			.spd(cycleInfo.getSpd())
-			.sum(cycleInfo.getSum())
 			.build();
 	}
 }


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

collector 주기 정보 저장시 안쓰이는 sum 값을 카프카에 이벤트 퍼블리싱할 때 보내고 있었습니다.
관련 객체에서 해당 필드를 삭제했습니다.

## #️⃣ 연관된 이슈

#295 

## 💡 리뷰어에게 하고 싶은 말

그리고 에뮬레이터에서 60개를 보낼 수 있는 상황인지 검사하는 조건문을 수정했습니다. 
- GpsTracker 인스턴스 필드인 cycleInfos 큐에 값이 있는지 확인하는 !cycleInfos.isEmpty() 조건을 isReadyToSendCycleInfo 에서부터 확인합니다.

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [ ] PR 이전 빌드 테스트 정상적으로 성공했나요?
      -> #296 이 반영되면 로컬 빌드 테스트까지 정상적으로 실행됩니다. 
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인