### PR TITLE
fix: 운행일지 상세조회 업무용 사용거리, 업무사용비율 로직 수정

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/DrivingLogSummary.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/DrivingLogSummary.java
@@ -1,30 +1,32 @@
 package org.controlcenter.vehicle.domain;
 
-import lombok.Getter;
-
 import org.controlcenter.history.domain.UsePurpose;
+
+import lombok.Getter;
 
 @Getter
 public class DrivingLogSummary {
 	int totalCount = 0;
-	int commuteCount = 0;
+	int normalCount = 0;
+	int businessDrivingDistance = 0;
 
 	public void accumulate(DrivingLogDetailsContent log) {
 		totalCount++;
 		if (log.getDrivingInfo() != null
 			&& log.getDrivingInfo().getBusinessDrivingDetails() != null
-			&& UsePurpose.COMMUTE.equals(
+			&& UsePurpose.NORMAL.equals(
 			log.getDrivingInfo().getBusinessDrivingDetails().getUsePurpose())) {
-			commuteCount++;
+			normalCount++;
+			businessDrivingDistance += log.getDrivingInfo().getTotalDriving();
 		}
 	}
 
 	public void combine(DrivingLogSummary other) {
 		this.totalCount += other.totalCount;
-		this.commuteCount += other.commuteCount;
+		this.normalCount += other.normalCount;
 	}
 
 	public int getCommutePercent() {
-		return totalCount == 0 ? 0 : (int)((commuteCount * 100) / totalCount);
+		return totalCount == 0 ? 0 : (int)((normalCount * 100) / totalCount);
 	}
 }


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- 운행일지 상세조회 업무용 사용거리, 업무사용비율 로직 수정
<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#311
<!-- ex) #이슈번호, #이슈번호 -->

## 💡 리뷰어에게 하고 싶은 말

- 업무용 사용거리를 출퇴근용 사용거리로 계산되고 있었고 업무사용비율이 출퇴근사용비율로 계산되고 있었습니다.
- 이부분 관련하여 수정하였습니다.
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인