### PR TITLE
fix: 차량 정보 조회 api 수정

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/application/AlarmService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/application/AlarmService.java
@@ -74,7 +74,7 @@ public class AlarmService {
 
 		Integer drivingDistance = null;
 
-		if (currentStatus == AlarmStatus.IN_PROGRESS) {
+		if (currentStatus == AlarmStatus.INPROGRESS) {
 			VehicleInformation vehicleInformation = vehicleRepository.findById(previousAlarm.getVehicleId())
 				.orElseThrow(() -> new BusinessException(ErrorCode.VEHICLE_NOT_FOUND));
 			drivingDistance = vehicleInformation.getSum();

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/AlarmStatus.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/AlarmStatus.java
@@ -13,10 +13,10 @@ public enum AlarmStatus {
 	SCHEDULED {
 		@Override
 		public AlarmStatus next() {
-			return IN_PROGRESS;
+			return INPROGRESS;
 		}
 	},
-	IN_PROGRESS {
+	INPROGRESS {
 		@Override
 		public AlarmStatus next() {
 			return COMPLETED;

--- a/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ErrorCode.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ErrorCode.java
@@ -25,8 +25,8 @@ public enum ErrorCode {
 	USER_ID_ALREADY_EXIST(1013, "다른 아이디를 입력해주세요."),
 	INVALID_DATE_RANGE(1014, "시작 날짜가 종료 날짜보다 이후로 입력하였습니다. 날짜를 확인해주세요."),
 
-	VEHICLE_NOT_FOUND(2001, "해당 차량을 찾을 수 없습니다."),
 	VEHICLE_NOT_MONITORED_YET(2000, "해당 차량의 위치 데이터를 찾을 수 없습니다"),
+	VEHICLE_NOT_FOUND(2001, "해당 차량을 찾을 수 없습니다."),
 	VEHICLE_ALREADY_EXIST(2002, "이미 등록되어 있는 차량입니다."),
 	VEHICLE_NUMBER_ERROR(2003, "입력된 차량 번호 형식이 올바르지 않습니다. 형식: 숫자 2~3자리 + 한글 1자리 + 숫자 4자리"),
 	INVALID_ZOOM_LEVEL(2004, "지도의 줌 레벨은 1~13 사이여야합니다."),

--- a/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ErrorCode.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
 	INVALID_DATE_RANGE(1014, "시작 날짜가 종료 날짜보다 이후로 입력하였습니다. 날짜를 확인해주세요."),
 
 	VEHICLE_NOT_FOUND(2001, "해당 차량을 찾을 수 없습니다."),
+	VEHICLE_NOT_MONITORED_YET(2000, "해당 차량의 위치 데이터를 찾을 수 없습니다"),
 	VEHICLE_ALREADY_EXIST(2002, "이미 등록되어 있는 차량입니다."),
 	VEHICLE_NUMBER_ERROR(2003, "입력된 차량 번호 형식이 올바르지 않습니다. 형식: 숫자 2~3자리 + 한글 1자리 + 숫자 4자리"),
 	INVALID_ZOOM_LEVEL(2004, "지도의 줌 레벨은 1~13 사이여야합니다."),

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleInformation.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/domain/VehicleInformation.java
@@ -23,6 +23,8 @@ public class VehicleInformation {
 	private Integer did;
 	private Integer drivingDays;
 	private Integer sum;
+	private Integer lat;
+	private Integer lng;
 	private VehicleStatus status;
 	private LocalDate deliveryDate;
 	private LocalDateTime createdAt;

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
@@ -2,6 +2,7 @@ package org.controlcenter.vehicle.infrastructure;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.controlcenter.common.exception.BusinessException;
 import org.controlcenter.common.response.code.ErrorCode;
@@ -76,9 +77,8 @@ public class VehicleQueryRepository {
 		return myBatisVehicleInfoMapper.getRecentVehicleInfo(vehicleId);
 	}
 
-	public VehicleModalResponse.RecentCycleInfo getRecentCycleInfo(Long vehicleId) {
-		return myBatisVehicleInfoMapper.getRecentCycleInfo(vehicleId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.VEHICLE_NOT_MONITORED_YET));
+	public Optional<VehicleModalResponse.RecentCycleInfo> getRecentCycleInfo(Long vehicleId) {
+		return myBatisVehicleInfoMapper.getRecentCycleInfo(vehicleId);
 	}
 
 	public VehicleModalResponse.TodayDrivingHistory getTodayDrivingHistory(Long vehicleId) {

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
@@ -3,6 +3,8 @@ package org.controlcenter.vehicle.infrastructure;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.controlcenter.common.exception.BusinessException;
+import org.controlcenter.common.response.code.ErrorCode;
 import org.controlcenter.vehicle.infrastructure.mybatis.MyBatisVehicleInfoMapper;
 import org.controlcenter.vehicle.presentation.RouteResponseWithStatus;
 import org.controlcenter.vehicle.presentation.dto.RouteResponse;
@@ -24,7 +26,8 @@ public class VehicleQueryRepository {
 	private final MyBatisVehicleInfoMapper myBatisVehicleInfoMapper;
 
 	public VehicleInfoResponse getVehicleInfo(VehicleInfoSearchRequest request) {
-		return myBatisVehicleInfoMapper.selectVehicleInfo(request.vehicleNumber());
+		return myBatisVehicleInfoMapper.selectVehicleInfo(request.vehicleNumber())
+			.orElseThrow(() -> new BusinessException(ErrorCode.VEHICLE_NOT_FOUND));
 	}
 
 	public List<RouteResponseWithAng> getVehicleRouteFrom(
@@ -74,7 +77,8 @@ public class VehicleQueryRepository {
 	}
 
 	public VehicleModalResponse.RecentCycleInfo getRecentCycleInfo(Long vehicleId) {
-		return myBatisVehicleInfoMapper.getRecentCycleInfo(vehicleId);
+		return myBatisVehicleInfoMapper.getRecentCycleInfo(vehicleId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.VEHICLE_NOT_MONITORED_YET));
 	}
 
 	public VehicleModalResponse.TodayDrivingHistory getTodayDrivingHistory(Long vehicleId) {

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
@@ -2,6 +2,7 @@ package org.controlcenter.vehicle.infrastructure.mybatis;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -40,7 +41,7 @@ public interface MyBatisVehicleInfoMapper {
 			where vi.vehicle_number = #{vehicleNumber}
 			  and vi.deleted_at is null;
 		""")
-	VehicleInfoResponse selectVehicleInfo(@Param("vehicleNumber") String vehicleNumber);
+	Optional<VehicleInfoResponse> selectVehicleInfo(@Param("vehicleNumber") String vehicleNumber);
 
 	/**
 	 * 1억개 데이터 기준
@@ -179,7 +180,7 @@ public interface MyBatisVehicleInfoMapper {
 		order by ci.interval_at DESC
 		limit 1
 		""")
-	VehicleModalResponse.RecentCycleInfo getRecentCycleInfo(@Param("vehicleId") Long vehicleId);
+	Optional<VehicleModalResponse.RecentCycleInfo> getRecentCycleInfo(@Param("vehicleId") Long vehicleId);
 
 	@Select("""
 		select

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
@@ -183,12 +183,13 @@ public interface MyBatisVehicleInfoMapper {
 
 	@Select("""
 		select
-			sum(driving_distance),
-			sum(timestampdiff(second, start_time, end_time))
+			IFNULL(sum(di.driving_distance), 0),
+			IFNULL(sum(timestampdiff(second, di.start_time, di.end_time)), 0)
 		from
-			driving_history
+			driving_history di
 		where
-			date(end_time) = curdate();
+			di.vehicle_id = #{vehicleId}
+			and date(end_time) = curdate();
 		""")
 	VehicleModalResponse.TodayDrivingHistory getTodayDrivingHistory(@Param("vehicleId") Long vehicleId);
 

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
@@ -98,8 +98,16 @@ public class VehicleController implements VehicleApi {
 	public BaseResponse<VehicleModalResponse> getVehicleInfo(
 		@PathVariable(name = "vehicle-id") Long vehicleId
 	) {
+		VehicleInformation vehicleInformation = vehicleService.getVehicleInformation(vehicleId);
 		var recentVehicleInfo = vehicleQueryRepository.getRecentVehicleInfo(vehicleId);
-		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleId);
+		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleId)
+			.orElse(VehicleModalResponse.RecentCycleInfo.builder()
+				.speed(0)
+				.lat(vehicleInformation.getLat())
+				.lng(vehicleInformation.getLng())
+				.lastUpdated(vehicleInformation.getUpdatedAt())
+				.build());
+		;
 		var todayDrivingHistory = vehicleQueryRepository.getTodayDrivingHistory(vehicleId);
 		var vehicleCompanyInfo = vehicleQueryRepository.getVehicleCompanyInfo(vehicleId);
 
@@ -123,7 +131,13 @@ public class VehicleController implements VehicleApi {
 		VehicleInformation vehicleInformation = vehicleService.getVehicleInformation(vehicleNumber);
 
 		String status = vehicleQueryRepository.getVehicleStatus(vehicleInformation.getId());
-		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleInformation.getId());
+		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleInformation.getId())
+			.orElse(VehicleModalResponse.RecentCycleInfo.builder()
+				.speed(0)
+				.lat(vehicleInformation.getLat())
+				.lng(vehicleInformation.getLng())
+				.lastUpdated(vehicleInformation.getUpdatedAt())
+				.build());
 
 		VehicleLocationResponse response = VehicleLocationResponse.builder()
 			.vehicleId(vehicleInformation.getId())
@@ -345,7 +359,13 @@ public class VehicleController implements VehicleApi {
 		VehicleInformation vehicleInformation = vehicleService.getVehicleInformation(vehicleId);
 
 		String status = vehicleQueryRepository.getVehicleStatus(vehicleInformation.getId());
-		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleInformation.getId());
+		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleInformation.getId())
+			.orElse(VehicleModalResponse.RecentCycleInfo.builder()
+				.speed(0)
+				.lat(vehicleInformation.getLat())
+				.lng(vehicleInformation.getLng())
+				.lastUpdated(vehicleInformation.getUpdatedAt())
+				.build());
 
 		VehicleLocationResponse response = VehicleLocationResponse.builder()
 			.vehicleId(vehicleInformation.getId())

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleModalResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleModalResponse.java
@@ -21,6 +21,7 @@ public record VehicleModalResponse(
 	) {
 	}
 
+	@Builder
 	public record RecentCycleInfo(
 		Integer speed,
 		Integer lat,

--- a/monicar-control-center/src/test/java/org/controlcenter/jpa/JpaTest.java
+++ b/monicar-control-center/src/test/java/org/controlcenter/jpa/JpaTest.java
@@ -93,7 +93,7 @@ public class JpaTest {
 		// given
 		Alarm alarm = Alarm.builder()
 			.managerId("100")
-			.status(AlarmStatus.IN_PROGRESS)
+			.status(AlarmStatus.INPROGRESS)
 			.build();
 		alarmJpaRepository.save(AlarmEntity.from(alarm));
 
@@ -110,7 +110,7 @@ public class JpaTest {
 		assertAll(
 			() -> assertThat(savedAlarm.getId()).isNotNull(),
 			() -> assertThat(savedAlarm.getManagerId()).isEqualTo("100"),
-			() -> assertThat(savedAlarm.getStatus()).isEqualTo(AlarmStatus.IN_PROGRESS)
+			() -> assertThat(savedAlarm.getStatus()).isEqualTo(AlarmStatus.INPROGRESS)
 		);
 	}
 


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

- 차량 상세 정보 조회 api에서 todayDrivingHistory(오늘 총 주행 거리, 총 주행 시간) 관련 데이터가 없으면 json에 null을 보내고 있는데, 0km와 0시간을 응답하도록 수정했습니다
- vehicle_information 데이터와 cycle_info 데이터가 일치하지 않아서(vehicle_information엔 lat과 lng가 있으나 cycle_info에는 없음), 클러스터링 -> 상세 조회로 이어지면 문제가 생기는 경우가 있습니다. mock data 이슈이긴 하나 mock data 싱크를 매번 맞출 수 없어서 예외처리 해놨습니다. 
- 이 외 데이터 null이면 예외 던지고 fail 응답

## #️⃣ 연관된 이슈

#312 

## 💡 리뷰어에게 하고 싶은 말

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [ ] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인