### PR TITLE
fix: mock 데이터 이슈는 mock 데이터 변경으로 해결하자

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ErrorCode.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/response/code/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 	USER_ID_ALREADY_EXIST(1013, "다른 아이디를 입력해주세요."),
 	INVALID_DATE_RANGE(1014, "시작 날짜가 종료 날짜보다 이후로 입력하였습니다. 날짜를 확인해주세요."),
 
+	VEHICLE_NOT_ON_YET(1999, "해당 차량은 최초 시동 on 전입니다"),
 	VEHICLE_NOT_MONITORED_YET(2000, "해당 차량의 위치 데이터를 찾을 수 없습니다"),
 	VEHICLE_NOT_FOUND(2001, "해당 차량을 찾을 수 없습니다."),
 	VEHICLE_ALREADY_EXIST(2002, "이미 등록되어 있는 차량입니다."),

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/VehicleQueryRepository.java
@@ -74,11 +74,13 @@ public class VehicleQueryRepository {
 	}
 
 	public VehicleModalResponse.RecentVehicleInfo getRecentVehicleInfo(Long vehicleId) {
-		return myBatisVehicleInfoMapper.getRecentVehicleInfo(vehicleId);
+		return myBatisVehicleInfoMapper.getRecentVehicleInfo(vehicleId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.VEHICLE_NOT_ON_YET));
 	}
 
-	public Optional<VehicleModalResponse.RecentCycleInfo> getRecentCycleInfo(Long vehicleId) {
-		return myBatisVehicleInfoMapper.getRecentCycleInfo(vehicleId);
+	public VehicleModalResponse.RecentCycleInfo getRecentCycleInfo(Long vehicleId) {
+		return myBatisVehicleInfoMapper.getRecentCycleInfo(vehicleId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.VEHICLE_NOT_MONITORED_YET));
 	}
 
 	public VehicleModalResponse.TodayDrivingHistory getTodayDrivingHistory(Long vehicleId) {

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleInformationEntity.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/jpa/entity/VehicleInformationEntity.java
@@ -81,6 +81,8 @@ public class VehicleInformationEntity {
 		vehicleInformationEntity.did = vehicleInformation.getDid();
 		vehicleInformationEntity.drivingDays = vehicleInformation.getDrivingDays();
 		vehicleInformationEntity.sum = vehicleInformation.getSum();
+		vehicleInformationEntity.lat = vehicleInformation.getLat();
+		vehicleInformationEntity.lng = vehicleInformation.getLat();
 		vehicleInformationEntity.status = vehicleInformation.getStatus();
 		vehicleInformationEntity.deliveryDate = vehicleInformation.getDeliveryDate();
 		vehicleInformationEntity.createdAt = vehicleInformation.getCreatedAt();
@@ -102,6 +104,8 @@ public class VehicleInformationEntity {
 			.did(did)
 			.drivingDays(drivingDays)
 			.sum(sum)
+			.lat(lat)
+			.lng(lng)
 			.status(status)
 			.deliveryDate(deliveryDate)
 			.createdAt(createdAt)

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
@@ -151,13 +151,7 @@ public interface MyBatisVehicleInfoMapper {
 			select
 				vi.vehicle_id,
 				vi.vehicle_number,
-				(
-					select ve2.type
-					from vehicle_event ve2
-					where ve2.vehicle_id = #{vehicleId}
-					order by ve2.event_at desc
-					limit 1
-				) as status,
+				vi.status,
 				max(case when ve.type = 'on' then ve.event_at end) as last_on_time,
 				max(case when ve.type = 'off' then ve.event_at end) as last_off_time
 			from
@@ -167,7 +161,7 @@ public interface MyBatisVehicleInfoMapper {
 			where
 				vi.vehicle_id = #{vehicleId};
 		""")
-	VehicleModalResponse.RecentVehicleInfo getRecentVehicleInfo(@Param("vehicleId") Long vehicleId);
+	Optional<VehicleModalResponse.RecentVehicleInfo> getRecentVehicleInfo(@Param("vehicleId") Long vehicleId);
 
 	@Select("""
 		select

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/VehicleController.java
@@ -101,16 +101,8 @@ public class VehicleController implements VehicleApi {
 	public BaseResponse<VehicleModalResponse> getVehicleInfo(
 		@PathVariable(name = "vehicle-id") Long vehicleId
 	) {
-		VehicleInformation vehicleInformation = vehicleService.getVehicleInformation(vehicleId);
 		var recentVehicleInfo = vehicleQueryRepository.getRecentVehicleInfo(vehicleId);
-		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleId)
-			.orElse(VehicleModalResponse.RecentCycleInfo.builder()
-				.speed(0)
-				.lat(vehicleInformation.getLat())
-				.lng(vehicleInformation.getLng())
-				.lastUpdated(vehicleInformation.getUpdatedAt())
-				.build());
-		;
+		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleId);
 		var todayDrivingHistory = vehicleQueryRepository.getTodayDrivingHistory(vehicleId);
 		var vehicleCompanyInfo = vehicleQueryRepository.getVehicleCompanyInfo(vehicleId);
 
@@ -134,13 +126,7 @@ public class VehicleController implements VehicleApi {
 		VehicleInformation vehicleInformation = vehicleService.getVehicleInformation(vehicleNumber);
 
 		String status = vehicleQueryRepository.getVehicleStatus(vehicleInformation.getId());
-		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleInformation.getId())
-			.orElse(VehicleModalResponse.RecentCycleInfo.builder()
-				.speed(0)
-				.lat(vehicleInformation.getLat())
-				.lng(vehicleInformation.getLng())
-				.lastUpdated(vehicleInformation.getUpdatedAt())
-				.build());
+		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleInformation.getId());
 
 		VehicleLocationResponse response = VehicleLocationResponse.builder()
 			.vehicleId(vehicleInformation.getId())
@@ -362,13 +348,7 @@ public class VehicleController implements VehicleApi {
 		VehicleInformation vehicleInformation = vehicleService.getVehicleInformation(vehicleId);
 
 		String status = vehicleQueryRepository.getVehicleStatus(vehicleInformation.getId());
-		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleInformation.getId())
-			.orElse(VehicleModalResponse.RecentCycleInfo.builder()
-				.speed(0)
-				.lat(vehicleInformation.getLat())
-				.lng(vehicleInformation.getLng())
-				.lastUpdated(vehicleInformation.getUpdatedAt())
-				.build());
+		var recentCycleInfo = vehicleQueryRepository.getRecentCycleInfo(vehicleInformation.getId());
 
 		VehicleLocationResponse response = VehicleLocationResponse.builder()
 			.vehicleId(vehicleInformation.getId())

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleModalResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/VehicleModalResponse.java
@@ -21,7 +21,6 @@ public record VehicleModalResponse(
 	) {
 	}
 
-	@Builder
 	public record RecentCycleInfo(
 		Integer speed,
 		Integer lat,
@@ -31,7 +30,7 @@ public record VehicleModalResponse(
 	}
 
 	public record TodayDrivingHistory(
-		Double distance,
+		Integer distance,
 		Integer drivingTime
 	) {
 	}


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

이전에 조회 결과가 null인 경우 복잡하게 데이터 넣어줬던거 삭제하고.. 예외만 던집니다.
왜냐하면 로직은 정상이었고(null인 경우 유저가 해당 api를 요청할 수 없습니다) mock 데이터 불일치로 생긴 이슈였기 때문입니다.

## #️⃣ 연관된 이슈

## 💡 리뷰어에게 하고 싶은 말

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인