### PR TITLE
fix: 에뮬레이터가 event hub 인스턴스에 on off 요청시 실패 응답

### DIFF
--- a/monicar-emulator/src/main/java/org/emulator/device/infrastructure/util/HeaderUtils.java
+++ b/monicar-emulator/src/main/java/org/emulator/device/infrastructure/util/HeaderUtils.java
@@ -11,7 +11,7 @@ import org.springframework.http.MediaType;
 
 public final class HeaderUtils {
 	private static final String CACHE_CONTROL_VALUE = "no-cache";
-	private static final String ACCEPT_ENCODING_VALUE = "gzip, deflate";
+	private static final String ACCEPT_ENCODING_VALUE = "identity";
 	private static final String KEY_VERSION_VALUE = "1.0";
 
 	public static Consumer<HttpHeaders> defaultHeaders() {


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

로드밸런서로 on / off 요청시 응답이 아래와 같이 오는 문제를 해결했습니다.
"I/O error on POST request for "https://monicar.uk/api/v1/event-hub/key-off/": Illegal character .."

## #️⃣ 연관된 이슈

#322 

## 💡 리뷰어에게 하고 싶은 말

요청 헤더에 Accept-Encoding 값을 gzip, deflate로 설정해서 보내고 있었는데요. identity로 바꿔서 해결했습니다.

Accept-Encoding: gzip, deflate를 설정하면, 압축된 응답을 반환할 수 있는데 응답 받은 서버가 압축을 해제하지 못하면 Illegal character 오류가 발생할 수 있다고 합니다. identity는 압축을 사용하지 않고 원본 그대로의 응답을 달라는 값입니다

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인