### PR TITLE
fix: X-Accel-Buffering을 사용하여 SSE 응답만 버퍼링하지 않도록 수정

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/presentation/AlarmController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/presentation/AlarmController.java
@@ -1,5 +1,7 @@
 package org.controlcenter.alarm.presentation;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.controlcenter.alarm.application.AlarmService;
 import org.controlcenter.alarm.domain.AlarmStatus;
 import org.controlcenter.alarm.presentation.dto.AlarmResponse;
@@ -37,9 +39,12 @@ public class AlarmController implements AlarmApi {
 
 	private final AlarmService alarmService;
 
-	@GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	@GetMapping(value = "/subscribe")
 	@PreAuthorize("hasRole('ROLE_USER')")
-	public SseEmitter subscribe(@AuthenticationPrincipal CustomUserDetails user) {
+	public SseEmitter subscribe(
+		HttpServletResponse response,
+		@AuthenticationPrincipal CustomUserDetails user) {
+		response.setHeader("X-Accel-Buffering", "no");
 		return alarmService.subscribe(user.getId());
 	}
 

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/presentation/swagger/AlarmApi.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/presentation/swagger/AlarmApi.java
@@ -15,12 +15,14 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
 @Tag(name = "실시간 알람 API", description = "실시간 알람 API")
 public interface AlarmApi {
 	@Operation(summary = "SSE 구독", description = "SSE 구독")
-	SseEmitter subscribe(@AuthenticationPrincipal CustomUserDetails user);
+	SseEmitter subscribe(
+		HttpServletResponse response, @AuthenticationPrincipal CustomUserDetails user);
 
 	@Operation(summary = "알람 승인 API", description = "점검 필요 -> 점검 예정 -> 점검 진행 -> 점검 완료로 순차적으로 상태 변경")
 	void next(


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- X-Accel-Buffering을 사용하여 SSE 응답만 버퍼링하지 않도록 수정
<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#326
<!-- ex) #이슈번호, #이슈번호 -->

## 💡 리뷰어에게 하고 싶은 말
- nginx 버퍼링 활성화로 인하여 전송이 안되는 문제였습니다.. SSE 응답시에만 버퍼링 비활성화되도록 수정하였습니다.
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인