### PR TITLE
fix: PropertyConfig dev에서만 쓰도록 어노테이션 추가

### DIFF
--- a/monicar-event-hub/src/main/java/org/eventhub/config/PropertyConfig.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/config/PropertyConfig.java
@@ -1,10 +1,12 @@
 package org.eventhub.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
 
 @Configuration
+@Profile("dev")
 @PropertySources(@PropertySource("classpath:properties/env.properties"))
 public class PropertyConfig {
 }


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

PropertyConfig를 application-dev.yml 에서만 쓰게 @Profile 어노테이션을 추가했습니다

## #️⃣ 연관된 이슈

#334 

## 💡 리뷰어에게 하고 싶은 말


## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인