### PR TITLE
fix: actuator 의존성 제거

### DIFF
--- a/monicar-event-hub/build.gradle
+++ b/monicar-event-hub/build.gradle
@@ -5,8 +5,6 @@ dependencies {
 
     implementation 'org.springframework.kafka:spring-kafka:3.3.0'
 
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
     // querydsl
     implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/monicar-event-hub/src/main/resources/application-dev.yml
+++ b/monicar-event-hub/src/main/resources/application-dev.yml
@@ -33,12 +33,12 @@ logging:
   file:
     path: ${user.dir}/logs
 
-management:
-  endpoints:
-    web:
-      base-path: /monitor
-      exposure:
-        include: health, metrics, threaddump
+#management:
+#  endpoints:
+#    web:
+#      base-path: /monitor
+#      exposure:
+#        include: health, metrics, threaddump
 
 api:
   key: ${API_KEY}


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

`Unhandled Exception 발생: No static resource zend/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php.`
`Unhandled Exception 발생: No static resource V2/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php.`
`Unhandled Exception 발생: No static resource tests/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php.`

event-hub에서 자꾸 저런 `org.springframework.web.servlet.resource.NoResourceFoundException` 에러가 나는데 gpt에 검색해보니 니가 요청한거 아니면 해킹 시도같답니다! actuator 의존성을 제거하면 노출이 줄어들까? 싶어서 제거해봅니다 (어차피 해당 라이브러리를 안쓰니까 제거해야했습니다. .)

## #️⃣ 연관된 이슈

<!-- ex) #이슈번호, #이슈번호 -->

## 💡 리뷰어에게 하고 싶은 말

-
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [ ] PR 이전 `dev` 브랜치 병합 하셨나요?
- [ ] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [ ] PR 상세내용이 충분히 기재 되었나요?
- [ ] PR 리뷰어, 할당자, 라벨, 프로젝트 확인