### PR TITLE
fix: 점검 상태별 통계 응답 시 상태값으로 반환하도록 수정

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/application/AlarmService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/application/AlarmService.java
@@ -157,19 +157,6 @@ public class AlarmService {
 	public List<AlarmStatusStatsResponse> getAlarmStatusCounts() {
 		List<AlarmStatusStats> rawData = alarmJpaRepository.findStatusCounts();
 		return rawData.stream()
-			.map(arr -> new AlarmStatusStatsResponse(
-				convertToKoreanName(arr.getName()),
-				arr.getCount()
-			)).toList();
-	}
-
-	// AlarmStatus -> 한글명 맵핑
-	private String convertToKoreanName(AlarmStatus status) {
-		return switch (status) {
-			case REQUIRED -> "점검요구";
-			case SCHEDULED -> "점검예정";
-			case INPROGRESS -> "점검진행중";
-			case COMPLETED -> "점검완료";
-		};
+			.map(AlarmStatusStatsResponse::from).toList();
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/AlarmStatusStats.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/AlarmStatusStats.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class AlarmStatusStats {
-	private AlarmStatus name;  // "점검요구", "점검예정", ...
+	private AlarmStatus status;
 	private long count;
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/presentation/dto/AlarmStatusStatsResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/presentation/dto/AlarmStatusStatsResponse.java
@@ -1,17 +1,18 @@
 package org.controlcenter.alarm.presentation.dto;
 
+import org.controlcenter.alarm.domain.AlarmStatus;
 import org.controlcenter.alarm.domain.AlarmStatusStats;
 
 import lombok.Builder;
 
 @Builder
 public record AlarmStatusStatsResponse(
-	String name,
+	AlarmStatus status,
 	long count
 ) {
 	public static AlarmStatusStatsResponse from(AlarmStatusStats alarmStatusStats) {
 		return AlarmStatusStatsResponse.builder()
-			.name(String.valueOf(alarmStatusStats.getName()))
+			.status(alarmStatusStats.getStatus())
 			.count(alarmStatusStats.getCount())
 			.build();
 	}


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- 점검 상태별 통계 응답 시 상태값으로 반환하도록 수정
<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#338
<!-- ex) #이슈번호, #이슈번호 -->

## 💡 리뷰어에게 하고 싶은 말
- 점검 상태별 통계 응답 시 원래 `name:"점검예정"` 이런 식으로 반환했었는데 `status:"SCHEDULED"`로 상태 값으로 반환하도록 수정하였습니다.
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인