### PR TITLE
fix: 점검 목록 조회 시 사용자가 확인하지 않은 목록만 반환하도록 수정

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/AlarmJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/AlarmJpaRepository.java
@@ -22,6 +22,7 @@ public interface AlarmJpaRepository extends JpaRepository<AlarmEntity, Long> {
 		"LEFT JOIN manager m ON a.managerId = m.id " +
 		"WHERE (:status IS NULL OR a.status = :status) " +
 		"  AND (:status IS NULL OR :status <> 'REQUIRED' OR a.managerId IS NULL) " +
+		"  AND a.isChecked = FALSE " +
 		"ORDER BY a.createdAt DESC")
 	Page<AlarmInfo> findAlarmListByStatus(@Param("status") AlarmStatus status,
 		Pageable pageable);
@@ -29,6 +30,7 @@ public interface AlarmJpaRepository extends JpaRepository<AlarmEntity, Long> {
 	@Query("SELECT new org.controlcenter.alarm.domain.AlarmStatusStats(a.status, COUNT(a)) " +
 		"FROM alarm a " +
 		"WHERE a.deletedAt IS NULL " +
+		"  AND a.isChecked = FALSE  " +
 		"GROUP BY a.status"
 	)
 	List<AlarmStatusStats> findStatusCounts();


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- 점검 목록 조회 시 사용자가 확인하지 않은 목록만 반환하도록 수정
<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#341
<!-- ex) #이슈번호, #이슈번호 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인