### PR TITLE
fix: 예외 처리로 원래 트랜잭션에 영향 없도록 하기

### DIFF
--- a/monicar-event-hub/src/main/java/org/eventhub/application/AlarmService.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/application/AlarmService.java
@@ -30,12 +30,16 @@ public class AlarmService {
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public Optional<Long> saveAlarmIfNecessary(Long vehicleId, Long totalDistance) {
-		boolean isNecessary = findById(vehicleId)
-			.map(alarm -> checkBiggerThanIntervalDistance(totalDistance, alarm.getDrivingDistance()))
-			.orElse(true);
+		try {
+			boolean isNecessary = alarmRepository.findByVehicleIdAlarmRequired(vehicleId)
+				.map(alarm -> checkBiggerThanIntervalDistance(totalDistance, alarm.getDrivingDistance()))
+				.orElse(true);
 
-		if (isNecessary) {
-			return Optional.ofNullable(alarmRepository.save(vehicleId));
+			if (isNecessary) {
+				return Optional.ofNullable(alarmRepository.save(vehicleId));
+			}
+		} catch (Exception e) {
+			log.error("Alarm 쿼리 예외 발생", e);
 		}
 		return Optional.empty();
 	}

--- a/monicar-event-hub/src/main/java/org/eventhub/application/port/AlarmRepository.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/application/port/AlarmRepository.java
@@ -6,5 +6,7 @@ import org.eventhub.domain.Alarm;
 
 public interface AlarmRepository {
 	Optional<Alarm> findByVehicleId(Long vehicleId);
+
+	Optional<Alarm> findByVehicleIdAlarmRequired(Long vehicleId);
 	Long save(Long vehicleId);
 }

--- a/monicar-event-hub/src/main/java/org/eventhub/infrastructure/repository/AlarmRepositoryAdapter.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/infrastructure/repository/AlarmRepositoryAdapter.java
@@ -2,6 +2,8 @@ package org.eventhub.infrastructure.repository;
 
 import java.util.Optional;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import lombok.RequiredArgsConstructor;
 
 import org.eventhub.application.port.AlarmRepository;
@@ -9,16 +11,32 @@ import org.eventhub.domain.Alarm;
 import org.eventhub.domain.AlarmStatus;
 import org.eventhub.infrastructure.repository.jpa.AlarmJpaRepository;
 import org.eventhub.infrastructure.repository.jpa.entity.AlarmEntity;
+import org.eventhub.infrastructure.repository.jpa.entity.QAlarmEntity;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
 public class AlarmRepositoryAdapter implements AlarmRepository {
 	private final AlarmJpaRepository alarmJpaRepository;
+	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public Optional<Alarm>  findByVehicleId(Long vehicleId) {
+	public Optional<Alarm> findByVehicleId(Long vehicleId) {
 		return alarmJpaRepository.findByVehicleId(vehicleId);
+	}
+
+	@Override
+	public Optional<Alarm> findByVehicleIdAlarmRequired(Long vehicleId) {
+		QAlarmEntity alarmEntity = QAlarmEntity.alarmEntity;
+
+		Optional<AlarmEntity> alarm = Optional.ofNullable(jpaQueryFactory.select(alarmEntity)
+			.from(alarmEntity)
+			.where(alarmEntity.id.eq(vehicleId)
+				.and(alarmEntity.status.eq(AlarmStatus.COMPLETED)))
+			.orderBy(alarmEntity.createdAt.desc())
+			.fetchFirst()
+		);
+		return alarm.map(AlarmEntity::toDomain);
 	}
 
 	@Override


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

알림 데이터를 저장하고 내부 서버에 알려줄 때, 알림 관련 처리는 되든 안되든 기존 off 로직에 영향이 없도록 @Transactional(propagation = Propagation.REQUIRES_NEW) 적용했는데요. 그게 안되는겁니다..
알고보니 던져진 예외를 알림 관련 선에서 해결해야 기존 로직에도 영향이 없었습니다(예외가 전파되지 않도록 해야하더라고요)

## #️⃣ 연관된 이슈

#340 

## 💡 리뷰어에게 하고 싶은 말

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인