### PR TITLE
fix: 알림 데이터 저장 에러 수정

### DIFF
--- a/monicar-event-hub/src/main/java/org/eventhub/application/AlarmService.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/application/AlarmService.java
@@ -33,9 +33,9 @@ public class AlarmService {
 	public Optional<Long> saveAlarmIfNecessary(Long vehicleId, Long totalDistance) {
 		try {
 			Optional<Alarm> alarm = alarmRepository.findRecentOneByVehicleId(vehicleId);
-			int referenceDistance = alarm.map(Alarm::getDrivingDistance).orElse(0);
+			int targetDistance = alarm.map(Alarm::getDrivingDistance).orElse(0);
 
-			if (checkBiggerThanIntervalDistance(totalDistance, referenceDistance)) {
+			if (checkBiggerThanIntervalDistance(totalDistance, targetDistance)) {
 				if (alarm.isEmpty() || alarm.get().getStatus().equals(AlarmStatus.COMPLETED)) {
 					return Optional.ofNullable(alarmRepository.save(vehicleId));
 				}

--- a/monicar-event-hub/src/main/java/org/eventhub/application/port/AlarmRepository.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/application/port/AlarmRepository.java
@@ -7,6 +7,6 @@ import org.eventhub.domain.Alarm;
 public interface AlarmRepository {
 	Optional<Alarm> findByVehicleId(Long vehicleId);
 
-	Optional<Alarm> findByVehicleIdAlarmRequired(Long vehicleId);
+	Optional<Alarm> findRecentOneByVehicleId(Long vehicleId);
 	Long save(Long vehicleId);
 }

--- a/monicar-event-hub/src/main/java/org/eventhub/infrastructure/repository/AlarmRepositoryAdapter.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/infrastructure/repository/AlarmRepositoryAdapter.java
@@ -26,13 +26,12 @@ public class AlarmRepositoryAdapter implements AlarmRepository {
 	}
 
 	@Override
-	public Optional<Alarm> findByVehicleIdAlarmRequired(Long vehicleId) {
+	public Optional<Alarm> findRecentOneByVehicleId(Long vehicleId) {
 		QAlarmEntity alarmEntity = QAlarmEntity.alarmEntity;
 
 		Optional<AlarmEntity> alarm = Optional.ofNullable(jpaQueryFactory.select(alarmEntity)
 			.from(alarmEntity)
-			.where(alarmEntity.id.eq(vehicleId)
-				.and(alarmEntity.status.eq(AlarmStatus.COMPLETED)))
+			.where(alarmEntity.vehicleId.eq(vehicleId))
 			.orderBy(alarmEntity.createdAt.desc())
 			.fetchFirst()
 		);


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

알림 데이터 저장을 판단하는 로직(AlarmService) 자체가 이상해서.. 로직을 바꾸고, 조회하는 쿼리도 이상해서.. 쿼리도 바꿨습니다.

## #️⃣ 연관된 이슈

#340 

## 💡 리뷰어에게 하고 싶은 말

vehicleId가 일치하는 최신 알림 데이터를 조회해요!
1. 데이터가 없는데 총 주행거리가 점검 기준 거리을 넘거나
2. 데이터가 (completed일 때 총 주행거리 - completed시 주행거리) 가 점검 기준 거리를 넘으면

알림 데이터를 저장하고 알림 요청을 보냅니다!

예전 로직은 당최 뭔 로직이었는지 기억도 안나네요,,

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인