### PR TITLE
fix: 지도 상태별 차량 대수 조회 문제 수정

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/common/security/JWTFilter.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/security/JWTFilter.java
@@ -70,8 +70,7 @@ public class JWTFilter extends OncePerRequestFilter {
 			return;
 		} catch (BusinessException e) {
 			response.addHeader("Set-Cookie", cookieUtil.createAccessTokenCookie("", 0L).toString());
-			response.addHeader("Set-Cookie",
-				cookieUtil.createRefreshTokenCookie("", 0L).toString());
+			response.addHeader("Set-Cookie", cookieUtil.createRefreshTokenCookie("", 0L).toString());
 			errorHandler.writeErrorResponse(response, e.getErrorCode());
 			return;
 

--- a/monicar-control-center/src/main/java/org/controlcenter/common/util/JWTTokenValidator.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/common/util/JWTTokenValidator.java
@@ -26,7 +26,7 @@ public class JWTTokenValidator {
 			throw new BusinessException(FORBIDDEN_ERROR);
 		}
 
-		if (!redisUtil.isRefreshTokenValid(extractUserIdFromAccessToken(refreshToken))) {
+		if (!redisUtil.getRefreshToken(extractUserIdFromAccessToken(refreshToken)).equals(refreshToken)) {
 			throw new BusinessException(FORBIDDEN_ERROR);
 		}
 

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/infrastructure/mybatis/MyBatisVehicleInfoMapper.java
@@ -236,6 +236,7 @@ public interface MyBatisVehicleInfoMapper {
 			) latest
 			ON ve.vehicle_id = latest.vehicle_id
 			AND ve.event_at = latest.latest_event_at
+				GROUP BY ve.vehicle_id
 		)
 		SELECT
 			COUNT(vi.vehicle_id) AS allVehicles,

--- a/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/SimpleVehicleInformationResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/vehicle/presentation/dto/SimpleVehicleInformationResponse.java
@@ -7,12 +7,12 @@ import org.controlcenter.vehicle.infrastructure.elasticsearch.document.VehicleIn
 
 @Builder
 public record SimpleVehicleInformationResponse(
-	long id,
+	long vehicleId,
 	String vehicleNumber
 ) {
 	public static SimpleVehicleInformationResponse from(VehicleInformationDocument doc) {
 		return SimpleVehicleInformationResponse.builder()
-			.id(doc.getId())
+			.vehicleId(doc.getId())
 			.vehicleNumber(doc.getVehicleNumber())
 			.build();
 	}


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- 지도 상태별 차량 대수 조회 시 2배로 조회되는 문제 수정
- 차량 자동완성 시 차량 ID 키값 `vehicleId`로 수정
<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#347 
<!-- ex) #이슈번호, #이슈번호 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [ ] PR 이전 `dev` 브랜치 병합 하셨나요?
- [ ] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [ ] PR 상세내용이 충분히 기재 되었나요?
- [ ] PR 리뷰어, 할당자, 라벨, 프로젝트 확인