### PR TITLE
fix: 알람 상태별 개수 통계 반환 방식 변경

### DIFF
--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/application/AlarmService.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/application/AlarmService.java
@@ -1,7 +1,6 @@
 package org.controlcenter.alarm.application;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -14,7 +13,6 @@ import org.controlcenter.alarm.domain.AlarmStatusStats;
 import org.controlcenter.alarm.domain.SendAlarm;
 import org.controlcenter.alarm.infrastructure.jpa.AlarmJpaRepository;
 import org.controlcenter.alarm.infrastructure.jpa.entity.AlarmEntity;
-import org.controlcenter.alarm.presentation.dto.AlarmStatusStatsResponse;
 import org.controlcenter.common.exception.BusinessException;
 import org.controlcenter.common.response.code.ErrorCode;
 import org.controlcenter.company.application.port.ManagerRepository;
@@ -154,9 +152,7 @@ public class AlarmService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<AlarmStatusStatsResponse> getAlarmStatusCounts() {
-		List<AlarmStatusStats> rawData = alarmJpaRepository.findStatusCounts();
-		return rawData.stream()
-			.map(AlarmStatusStatsResponse::from).toList();
+	public AlarmStatusStats getAlarmStatusCounts() {
+		return alarmJpaRepository.findStatusCounts();
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/AlarmStatusStats.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/domain/AlarmStatusStats.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class AlarmStatusStats {
-	private AlarmStatus status;
-	private long count;
+	private Long required;
+	private Long scheduled;
+	private Long inProgress;
+	private Long completed;
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/AlarmJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/AlarmJpaRepository.java
@@ -31,7 +31,7 @@ public interface AlarmJpaRepository extends JpaRepository<AlarmEntity, Long> {
 		    SELECT new org.controlcenter.alarm.domain.AlarmStatusStats(
 		        SUM(CASE WHEN a.status = 'REQUIRED' THEN 1 ELSE 0 END),
 		        SUM(CASE WHEN a.status = 'SCHEDULED' THEN 1 ELSE 0 END),
-		        SUM(CASE WHEN a.status = 'IN_PROGRESS' THEN 1 ELSE 0 END),
+		        SUM(CASE WHEN a.status = 'INPROGRESS' THEN 1 ELSE 0 END),
 		        SUM(CASE WHEN a.status = 'COMPLETED' THEN 1 ELSE 0 END)
 		    )
 		    FROM alarm a

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/AlarmJpaRepository.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/infrastructure/jpa/AlarmJpaRepository.java
@@ -27,12 +27,14 @@ public interface AlarmJpaRepository extends JpaRepository<AlarmEntity, Long> {
 	Page<AlarmInfo> findAlarmListByStatus(@Param("status") AlarmStatus status,
 		Pageable pageable);
 
-	@Query("SELECT new org.controlcenter.alarm.domain.AlarmStatusStats(a.status, COUNT(a)) " +
-		"FROM alarm a " +
-		"WHERE a.deletedAt IS NULL " +
-		"  AND a.isChecked = FALSE  " +
-		"GROUP BY a.status"
-	)
-	List<AlarmStatusStats> findStatusCounts();
-
+	@Query("""
+		    SELECT new org.controlcenter.alarm.domain.AlarmStatusStats(
+		        SUM(CASE WHEN a.status = 'REQUIRED' THEN 1 ELSE 0 END),
+		        SUM(CASE WHEN a.status = 'SCHEDULED' THEN 1 ELSE 0 END),
+		        SUM(CASE WHEN a.status = 'IN_PROGRESS' THEN 1 ELSE 0 END),
+		        SUM(CASE WHEN a.status = 'COMPLETED' THEN 1 ELSE 0 END)
+		    )
+		    FROM alarm a
+		""")
+	AlarmStatusStats findStatusCounts();
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/presentation/AlarmController.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/presentation/AlarmController.java
@@ -1,9 +1,5 @@
 package org.controlcenter.alarm.presentation;
 
-import jakarta.servlet.http.HttpServletResponse;
-
-import java.util.List;
-
 import org.controlcenter.alarm.application.AlarmService;
 import org.controlcenter.alarm.domain.AlarmStatus;
 import org.controlcenter.alarm.presentation.dto.AlarmResponse;
@@ -17,7 +13,6 @@ import org.controlcenter.common.security.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -85,9 +81,10 @@ public class AlarmController implements AlarmApi {
 	}
 
 	@GetMapping("/status/stats")
-	public BaseResponse<List<AlarmStatusStatsResponse>> getAlarmStatusStats() {
+	public BaseResponse<AlarmStatusStatsResponse> getAlarmStatusStats() {
+		var alarmStatusStats = alarmService.getAlarmStatusCounts();
 		return BaseResponse.success(
-			alarmService.getAlarmStatusCounts()
+			AlarmStatusStatsResponse.from(alarmStatusStats)
 		);
 	}
 }

--- a/monicar-control-center/src/main/java/org/controlcenter/alarm/presentation/dto/AlarmStatusStatsResponse.java
+++ b/monicar-control-center/src/main/java/org/controlcenter/alarm/presentation/dto/AlarmStatusStatsResponse.java
@@ -1,19 +1,22 @@
 package org.controlcenter.alarm.presentation.dto;
 
-import org.controlcenter.alarm.domain.AlarmStatus;
 import org.controlcenter.alarm.domain.AlarmStatusStats;
 
 import lombok.Builder;
 
 @Builder
 public record AlarmStatusStatsResponse(
-	AlarmStatus status,
-	long count
+	Long required,
+	Long scheduled,
+	Long inProgress,
+	Long completed
 ) {
 	public static AlarmStatusStatsResponse from(AlarmStatusStats alarmStatusStats) {
 		return AlarmStatusStatsResponse.builder()
-			.status(alarmStatusStats.getStatus())
-			.count(alarmStatusStats.getCount())
+			.required(alarmStatusStats.getRequired())
+			.scheduled(alarmStatusStats.getScheduled())
+			.inProgress(alarmStatusStats.getInProgress())
+			.completed(alarmStatusStats.getCompleted())
 			.build();
 	}
 }


### PR DESCRIPTION
## 🔧 어떤 작업인가요?
- 원래 배열로 통계를 반환하였는데, 프론트엔드와 백엔드 측면으로 잘못된 반환 방식이라고 생각하여, 배열에서 객체로 반환하도록 수정하였습니다.
```json
// before
[
    {
      "status": "COMPLETED",
      "count": 93
    },
    {
      "status": "INPROGRESS",
      "count": 86
    },
    {
      "status": "SCHEDULED",
      "count": 97
    },
    {
      "status": "REQUIRED",
      "count": 91
    }
]

// after
{
    "required": 0,
    "scheduled": 1,
    "inProgress": 0,
    "completed": 3
}
```

<!-- 추가하려는 작업에 대해 간결하게 설명해주세요 -->

## #️⃣ 연관된 이슈
#355
<!-- ex) #이슈번호, #이슈번호 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인