### PR TITLE
Fix/#365 alarm entity 수정

### DIFF
--- a/monicar-event-hub/src/main/java/org/eventhub/domain/Alarm.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/domain/Alarm.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 public class Alarm {
 	private Long id;
-	private Long managerId;
+	private String managerId;
 	private Long vehicleId;
 	private Integer drivingDistance;
 	private AlarmStatus status;

--- a/monicar-event-hub/src/main/java/org/eventhub/infrastructure/repository/jpa/entity/AlarmEntity.java
+++ b/monicar-event-hub/src/main/java/org/eventhub/infrastructure/repository/jpa/entity/AlarmEntity.java
@@ -29,7 +29,7 @@ public class AlarmEntity {
 	@Column(name = "alarm_id")
 	private Long id;
 
-	private Long managerId;
+	private String managerId;
 
 	private Long vehicleId;
 

--- a/monicar-event-hub/src/main/resources/application-prod.yml
+++ b/monicar-event-hub/src/main/resources/application-prod.yml
@@ -41,4 +41,4 @@ api:
   base-url: ${PROD_API_BASE_URL}
 
 
-alarm-interval-distance: 5000
+alarm-interval-distance: 100

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,5 @@ include 'monicar-emulator'
 include 'monicar-control-center'
 include 'monicar-collector'
 include 'monicar-common'
-include 'monicar-track-alert'
 include 'monicar-event-hub'
 


### PR DESCRIPTION
## 🔧 어떤 작업인가요?

이벤트 허브에서 쓰는 알림 엔티티의 타입이 DB와 불일치하여 변경했습니다.
Long -> String

## #️⃣ 연관된 이슈

#365 

## 💡 리뷰어에게 하고 싶은 말

그 외에 sse 구현을 마구 뽐내기 위해서는 알림 주기가 5000보다 작아야하므로 100으로 줄였습니다.
노션과 시크릿키도 업데이트 할게요!

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인